### PR TITLE
added locking to sequence_impl

### DIFF
--- a/include/turtle/detail/sequence_impl.hpp
+++ b/include/turtle/detail/sequence_impl.hpp
@@ -22,24 +22,30 @@ namespace detail
     class sequence_impl : private boost::noncopyable
     {
     public:
+        sequence_impl() : mutex_( boost::make_shared< mutex >() ) {}
+        
         void add( void* e )
         {
+            lock _( mutex_ );
             elements_.push_back( e );
         }
         void remove( void* e )
         {
+            lock _( mutex_ );
             elements_.erase( std::remove( elements_.begin(),
                 elements_.end(), e ), elements_.end() );
         }
 
         bool is_valid( const void* e ) const
         {
+            lock _( mutex_ );
             return std::find( elements_.begin(), elements_.end(), e )
                 != elements_.end();
         }
 
         void invalidate( const void* e )
         {
+            lock _( mutex_ );
             elements_type::iterator it =
                 std::find( elements_.begin(), elements_.end(), e );
             if( it != elements_.end() )
@@ -50,6 +56,8 @@ namespace detail
         typedef std::vector< void* > elements_type;
 
         elements_type elements_;
+        
+        const boost::shared_ptr< mutex > mutex_;
     };
 }
 } // mock

--- a/include/turtle/detail/sequence_impl.hpp
+++ b/include/turtle/detail/sequence_impl.hpp
@@ -10,6 +10,7 @@
 #define MOCK_SEQUENCE_IMPL_HPP_INCLUDED
 
 #include "../config.hpp"
+#include "mutex.hpp"
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <algorithm>

--- a/include/turtle/sequence.hpp
+++ b/include/turtle/sequence.hpp
@@ -10,8 +10,8 @@
 #define MOCK_SEQUENCE_HPP_INCLUDED
 
 #include "config.hpp"
-#include "detail/sequence_impl.hpp"
 #include <boost/make_shared.hpp>
+#include "detail/sequence_impl.hpp"
 
 namespace mock
 {


### PR DESCRIPTION
While debugging tests for my project with [thread sanitizer](https://code.google.com/p/thread-sanitizer/) I ran across a race condition related to mock::sequence.

Here is a gist with code to reproduce the issue: https://gist.github.com/robwiss/06ef1cc830f43a91a57b

If you are on Ubuntu you may need to ```apt-get install libtsan-dbg``` to compile. Other platforms have similar packages.

By adding locking to sequence_impl similar to the locking implemented in other turtle classes I was able to fix the issue. The changes are contained in this pull request.