### PR TITLE
Fixed extra semicolon warning with BOOST_GLOBAL_FIXTURE prior to Boost 1.59

### DIFF
--- a/doc/changelog.qbk
+++ b/doc/changelog.qbk
@@ -13,6 +13,7 @@ Not yet released
 * Fixed missing thread synchronization in mock::sequence
 * Fixed build errors with Boost 1.59
 * Fixed multiply defined symbol definition for MOCK_FUNCTION included from several translation units
+* Fixed extra semicolon warning with BOOST_GLOBAL_FIXTURE prior to Boost 1.59
 
 [endsect]
 

--- a/include/turtle/cleanup.hpp
+++ b/include/turtle/cleanup.hpp
@@ -27,7 +27,10 @@ namespace mock
     };
 
 #ifdef MOCK_USE_BOOST_TEST
-    BOOST_GLOBAL_FIXTURE( cleanup );
+    BOOST_GLOBAL_FIXTURE( cleanup )
+#if BOOST_VERSION >= 105900
+        ;
+#endif
 #endif
 
 } // mock


### PR DESCRIPTION
supersedes https://github.com/mat007/turtle/pull/21
https://sourceforge.net/p/turtle/tickets/61/