### PR TITLE
Virtually derive from mock::object

### DIFF
--- a/doc/changelog.qbk
+++ b/doc/changelog.qbk
@@ -18,6 +18,8 @@ Not yet released
 * Added support for dereferencing in mock::equal
 * Added support for movable objects in mock::retrieve
 * Fixed deprecation warning about std::uncaught_exception in c++17 for msvc
+* Added virtual inheritance to mock::object defined with MOCK_BASE_CLASS and MOCK_CLASS
+* Added virtual to destructors defined with MOCK_DESTRUCTOR
 
 [endsect]
 

--- a/include/turtle/mock.hpp
+++ b/include/turtle/mock.hpp
@@ -25,7 +25,7 @@
 #include <boost/mpl/assert.hpp>
 
 #define MOCK_CLASS(T) \
-    struct T : mock::object
+    struct T : virtual mock::object
 
 #define MOCK_FUNCTION_TYPE(S, tpn) \
     tpn boost::remove_pointer< tpn BOOST_IDENTITY_TYPE(S) >::type
@@ -33,7 +33,8 @@
 #ifdef MOCK_VARIADIC_MACROS
 
 #define MOCK_BASE_CLASS(T, ...) \
-    struct T : __VA_ARGS__, mock::object, mock::detail::base< __VA_ARGS__ >
+    struct T : __VA_ARGS__, virtual mock::object, \
+        virtual mock::detail::base< __VA_ARGS__ >
 
 #define MOCK_FUNCTOR(f, ...) \
     mock::detail::functor< MOCK_FUNCTION_TYPE((__VA_ARGS__),) > f, f##_mock
@@ -43,8 +44,8 @@
 
 #else // MOCK_VARIADIC_MACROS
 
-#define MOCK_BASE_CLASS(T, I) \
-    struct T : I, mock::object, mock::detail::base< I >
+#define MOCK_BASE_CLASS(T, B) \
+    struct T : B, virtual mock::object, virtual mock::detail::base< B >
 
 #define MOCK_FUNCTOR(f, S) \
     mock::detail::functor< MOCK_FUNCTION_TYPE((S),) > f, f##_mock
@@ -164,7 +165,7 @@
     MOCK_CONSTRUCTOR_AUX(T, n, A, t, typename)
 
 #define MOCK_DESTRUCTOR(T, t) \
-    T() { try { MOCK_ANONYMOUS_HELPER(t)(); } catch( ... ) {} } \
+    virtual T() { try { MOCK_ANONYMOUS_HELPER(t)(); } catch( ... ) {} } \
     MOCK_METHOD_HELPER(void(), t,)
 
 #define MOCK_FUNCTION_AUX(F, n, S, t, s, tpn) \

--- a/test/test_mock.cpp
+++ b/test/test_mock.cpp
@@ -462,3 +462,46 @@ namespace stdcall
 
     MOCK_FUNCTION( MOCK_STDCALL f, 0, void(), f )
 }
+
+namespace
+{
+    MOCK_CLASS( base_1 )
+    {
+        MOCK_DESTRUCTOR( ~base_1, base_1_destructor )
+
+        virtual void f_1() = 0;
+    };
+    MOCK_CLASS( base_2 )
+    {
+        MOCK_DESTRUCTOR( ~base_2, base_2_destructor )
+
+        virtual void f_2() = 0;
+    };
+    MOCK_BASE_CLASS( mock_1, base_1 )
+    {
+        MOCK_DESTRUCTOR( ~mock_1, mock_1_destructor )
+
+        MOCK_METHOD( f_1, 0 )
+    };
+    MOCK_BASE_CLASS( mock_2, base_2 ), mock_1
+    {
+        MOCK_DESTRUCTOR( ~mock_2, mock_2_destructor )
+
+        MOCK_METHOD( f_2, 0 )
+    };
+}
+
+BOOST_AUTO_TEST_CASE( mock_object_can_inherit_from_another_mock_object )
+{
+    mock_2 m;
+    MOCK_EXPECT( m.f_1 ).once();
+    MOCK_EXPECT( m.f_2 ).once();
+    m.f_1();
+    m.f_2();
+    mock::verify( m );
+    mock::reset( m );
+    MOCK_EXPECT( m.mock_2_destructor ).once();
+    MOCK_EXPECT( m.mock_1_destructor ).once();
+    MOCK_EXPECT( m.base_2_destructor ).once();
+    MOCK_EXPECT( m.base_1_destructor ).once();
+}


### PR DESCRIPTION
Added virtual inheritance to mock::object defined with MOCK_BASE_CLASS and MOCK_CLASS

Added virtual to destructors defined with MOCK_DESTRUCTOR

This makes it more convenient to set up complex hierarchies of classes for testing.