### PR TITLE
Make mock::object::~object() virtual

### DIFF
--- a/include/turtle/object.hpp
+++ b/include/turtle/object.hpp
@@ -51,7 +51,7 @@ namespace detail
             : impl_( boost::make_shared< detail::object_impl >() )
         {}
     protected:
-        ~object()
+        virtual ~object()
         {}
     public:
         boost::shared_ptr< detail::object_impl > impl_;


### PR DESCRIPTION
I'm in the process of updating our project to GCC 7(.3) and I'm now running into the following error when trying to instantiate a `mock::object` subclass:
```
error: 'mock::object::~object()' is protected within this context
```

Was there any specific reason not to make this dtor virtual? 
Another way of fixing the issue would of course be to make the dtor public instead.

I have no setup to compile the turtle testsuite locally, I can just say that this fixes our tests - let's see what travis says.

P.S.: I've seen https://github.com/mat007/turtle/pull/29 but that seems harder to get finished than fixing this very issue on its own, if you want to pick that one up again, of course also appreciated.

edit:
Actually GCC 7.3 did not "break" the build, it must have been the switch from `-std=c++1y` to `-std=c++17`.