### PR TITLE
Solution of missing boost/test/utils/trivial_singleton.hpp - issue #50

### DIFF
--- a/include/turtle/detail/functor.hpp
+++ b/include/turtle/detail/functor.hpp
@@ -15,38 +15,38 @@
 
 namespace mock
 {
-namespace detail
-{
-    class functor_mutex_t :
-        public boost::unit_test::singleton< functor_mutex_t >,
-        public mutex
-    {
-    private:
-        BOOST_TEST_SINGLETON_CONS( functor_mutex_t );
-    };
-    BOOST_TEST_SINGLETON_INST( functor_mutex )
+	namespace detail
+	{
+		class functor_mutex_t :
+			public boost::unit_test::singleton< functor_mutex_t >,
+			public mutex
+		{
+		private:
+			MOCK_SINGLETON_CONS(functor_mutex_t);
+		};
+		MOCK_SINGLETON_INST(functor_mutex)
 
-    template< typename Signature >
-    struct functor : function< Signature >
-    {
-        functor()
-        {
-            scoped_lock _( functor_mutex );
-            static functor* f = 0;
-            if( f )
-            {
-                *this = *f;
-                f = 0;
-                functor_mutex.unlock();
-            }
-            else
-            {
-                functor_mutex.lock();
-                f = this;
-            }
-        }
-    };
-}
+			template< typename Signature >
+		struct functor : function< Signature >
+		{
+			functor()
+			{
+				scoped_lock _(functor_mutex);
+				static functor* f = 0;
+				if (f)
+				{
+					*this = *f;
+					f = 0;
+					functor_mutex.unlock();
+				}
+				else
+				{
+					functor_mutex.lock();
+					f = this;
+				}
+			}
+		};
+	}
 } // mock
 
 #endif // MOCK_FUNCTOR_HPP_INCLUDED

--- a/include/turtle/detail/mutex.hpp
+++ b/include/turtle/detail/mutex.hpp
@@ -10,7 +10,7 @@
 #define MOCK_MUTEX_HPP_INCLUDED
 
 #include "../config.hpp"
-#include <boost/test/utils/trivial_singleton.hpp>
+#include <turtle/detail/singleton.hpp>
 #include <boost/shared_ptr.hpp>
 
 #ifdef MOCK_THREAD_SAFE

--- a/include/turtle/detail/mutex.hpp
+++ b/include/turtle/detail/mutex.hpp
@@ -10,8 +10,7 @@
 #define MOCK_MUTEX_HPP_INCLUDED
 
 #include "../config.hpp"
-#include <turtle/detail/singleton.hpp>
-
+#include <boost/test/utils/trivial_singleton.hpp>
 #include <boost/shared_ptr.hpp>
 
 #ifdef MOCK_THREAD_SAFE

--- a/include/turtle/detail/mutex.hpp
+++ b/include/turtle/detail/mutex.hpp
@@ -10,7 +10,8 @@
 #define MOCK_MUTEX_HPP_INCLUDED
 
 #include "../config.hpp"
-#include <boost/test/utils/trivial_singleton.hpp>
+#include <turtle/detail/singleton.hpp>
+
 #include <boost/shared_ptr.hpp>
 
 #ifdef MOCK_THREAD_SAFE
@@ -24,118 +25,118 @@
 
 namespace mock
 {
-namespace detail
-{
+	namespace detail
+	{
 #ifdef MOCK_HDR_MUTEX
-    typedef std::recursive_mutex mutex;
-    typedef std::lock_guard< mutex > scoped_lock;
+		typedef std::recursive_mutex mutex;
+		typedef std::lock_guard< mutex > scoped_lock;
 #else
-    typedef boost::recursive_mutex mutex;
-    typedef boost::lock_guard< mutex > scoped_lock;
+		typedef boost::recursive_mutex mutex;
+		typedef boost::lock_guard< mutex > scoped_lock;
 #endif
 
-    struct lock
-    {
-        lock( const boost::shared_ptr< mutex >& m )
-            : m_( m )
-        {
-            m_->lock();
-        }
-        lock( const lock& rhs )
-        {
-            m_.swap( rhs.m_ );
-        }
-        ~lock()
-        {
-            if( m_ )
-                m_->unlock();
-        }
+		struct lock
+		{
+			lock(const boost::shared_ptr< mutex >& m)
+				: m_(m)
+			{
+				m_->lock();
+			}
+			lock(const lock& rhs)
+			{
+				m_.swap(rhs.m_);
+			}
+			~lock()
+			{
+				if (m_)
+					m_->unlock();
+			}
 
-    private:
-        lock& operator=( const lock& rhs );
+		private:
+			lock& operator=(const lock& rhs);
 
-        mutable boost::shared_ptr< mutex > m_;
-    };
-}
+			mutable boost::shared_ptr< mutex > m_;
+		};
+	}
 } // mock
 
 #else // MOCK_THREAD_SAFE
 
 namespace mock
 {
-namespace detail
-{
-    struct mutex
-    {
-        mutex()
-        {}
-        void lock()
-        {}
-        void unlock()
-        {}
-    };
-    struct scoped_lock
-    {
-        scoped_lock( mutex& )
-        {}
-    };
-    struct lock
-    {
-        lock( const boost::shared_ptr< mutex >& )
-        {}
-    };
-}
+	namespace detail
+	{
+		struct mutex
+		{
+			mutex()
+			{}
+			void lock()
+			{}
+			void unlock()
+			{}
+		};
+		struct scoped_lock
+		{
+			scoped_lock(mutex&)
+			{}
+		};
+		struct lock
+		{
+			lock(const boost::shared_ptr< mutex >&)
+			{}
+		};
+	}
 } // mock
 
 #endif // MOCK_THREAD_SAFE
 
 namespace mock
 {
-namespace detail
-{
-    class error_mutex_t : public boost::unit_test::singleton< error_mutex_t >,
-        public mutex
-    {
-    private:
-        BOOST_TEST_SINGLETON_CONS( error_mutex_t );
-    };
-    BOOST_TEST_SINGLETON_INST( error_mutex )
+	namespace detail
+	{
+		class error_mutex_t : public boost::unit_test::singleton< error_mutex_t >,
+			public mutex
+		{
+		private:
+			MOCK_SINGLETON_CONS(error_mutex_t);
+		};
+		MOCK_SINGLETON_INST(error_mutex)
 
 #ifdef BOOST_MSVC
 #   pragma warning( push )
 #   pragma warning( disable: 4702 )
 #endif
-    template< typename Result, typename Error >
-    struct safe_error
-    {
-        static Result abort()
-        {
-            scoped_lock _( error_mutex );
-            return Error::abort();
-        }
-        template< typename Context >
-        static void fail( const char* message, const Context& context,
-            const char* file = "unknown location", int line = 0 )
-        {
-            scoped_lock _( error_mutex );
-            Error::fail( message, context, file, line );
-        }
-        template< typename Context >
-        static void call( const Context& context, const char* file, int line )
-        {
-            scoped_lock _( error_mutex );
-            Error::call( context, file, line );
-        }
-        static void pass( const char* file, int line )
-        {
-            scoped_lock _( error_mutex );
-            Error::pass( file, line );
-        }
-    };
+			template< typename Result, typename Error >
+		struct safe_error
+		{
+			static Result abort()
+			{
+				scoped_lock _(error_mutex);
+				return Error::abort();
+			}
+			template< typename Context >
+			static void fail(const char* message, const Context& context,
+				const char* file = "unknown location", int line = 0)
+			{
+				scoped_lock _(error_mutex);
+				Error::fail(message, context, file, line);
+			}
+			template< typename Context >
+			static void call(const Context& context, const char* file, int line)
+			{
+				scoped_lock _(error_mutex);
+				Error::call(context, file, line);
+			}
+			static void pass(const char* file, int line)
+			{
+				scoped_lock _(error_mutex);
+				Error::pass(file, line);
+			}
+		};
 #ifdef BOOST_MSVC
 #   pragma warning( pop )
 #endif
-}
+	}
 } // mock
 
 #endif // MOCK_MUTEX_HPP_INCLUDED

--- a/include/turtle/detail/root.hpp
+++ b/include/turtle/detail/root.hpp
@@ -15,124 +15,124 @@
 #include "context.hpp"
 #include "child.hpp"
 #include "mutex.hpp"
-#include <boost/test/utils/trivial_singleton.hpp>
+#include "singleton.hpp"
 #include <boost/optional.hpp>
 #include <ostream>
 #include <map>
 
 namespace mock
 {
-namespace detail
-{
-    class root_t : public boost::unit_test::singleton< root_t >, public context
-    {
-    public:
-        virtual void add( const void* p, verifiable& v,
-            boost::unit_test::const_string instance,
-            boost::optional< type_name > type,
-            boost::unit_test::const_string name )
-        {
-            scoped_lock _( mutex_ );
-            children_t::iterator it = children_.lower_bound( &v );
-            if( it == children_.end() ||
-                children_.key_comp()( &v, it->first ) )
-                it = children_.insert( it,
-                    std::make_pair( &v, counter_child( parents_, p ) ) );
-            it->second.update( instance, type, name );
-        }
-        virtual void add( verifiable& v )
-        {
-            scoped_lock _( mutex_ );
-            group_.add( v );
-        }
+	namespace detail
+	{
+		class root_t : public boost::unit_test::singleton< root_t >, public context
+		{
+		public:
+			virtual void add(const void* p, verifiable& v,
+				boost::unit_test::const_string instance,
+				boost::optional< type_name > type,
+				boost::unit_test::const_string name)
+			{
+				scoped_lock _(mutex_);
+				children_t::iterator it = children_.lower_bound(&v);
+				if (it == children_.end() ||
+					children_.key_comp()(&v, it->first))
+					it = children_.insert(it,
+						std::make_pair(&v, counter_child(parents_, p)));
+				it->second.update(instance, type, name);
+			}
+			virtual void add(verifiable& v)
+			{
+				scoped_lock _(mutex_);
+				group_.add(v);
+			}
 
-        virtual void remove( verifiable& v )
-        {
-            scoped_lock _( mutex_ );
-            group_.remove( v );
-            children_.erase( &v );
-        }
+			virtual void remove(verifiable& v)
+			{
+				scoped_lock _(mutex_);
+				group_.remove(v);
+				children_.erase(&v);
+			}
 
-        bool verify() const
-        {
-            scoped_lock _( mutex_ );
-            return group_.verify();
-        }
-        void reset()
-        {
-            scoped_lock _( mutex_ );
-            group_.reset();
-        }
+			bool verify() const
+			{
+				scoped_lock _(mutex_);
+				return group_.verify();
+			}
+			void reset()
+			{
+				scoped_lock _(mutex_);
+				group_.reset();
+			}
 
-        virtual void serialize( std::ostream& s, const verifiable& v ) const
-        {
-            scoped_lock _( mutex_ );
-            children_cit it = children_.find( &v );
-            if( it != children_.end() )
-                s << it->second;
-            else
-                s << "?";
-        }
+			virtual void serialize(std::ostream& s, const verifiable& v) const
+			{
+				scoped_lock _(mutex_);
+				children_cit it = children_.find(&v);
+				if (it != children_.end())
+					s << it->second;
+				else
+					s << "?";
+			}
 
-    private:
-        typedef std::map< const void*,
-            std::pair< parent, std::size_t > > parents_t;
+		private:
+			typedef std::map< const void*,
+				std::pair< parent, std::size_t > > parents_t;
 
-        class counter_child
-        {
-        public:
-            counter_child( parents_t& parents, const void* p )
-                : parents_( &parents )
-                , it_( parents.insert(
-                    std::make_pair( p, parents_t::mapped_type() ) ).first )
-            {
-                ++it_->second.second;
-            }
-            counter_child( const counter_child& rhs )
-                : parents_( rhs.parents_ )
-                , it_( rhs.it_ )
-                , child_( rhs.child_ )
-            {
-                ++it_->second.second;
-            }
-            ~counter_child()
-            {
-                if( --it_->second.second == 0 )
-                    parents_->erase( it_ );
-            }
-            void update( boost::unit_test::const_string instance,
-                boost::optional< type_name > type,
-                boost::unit_test::const_string name )
-            {
-                child_.update( it_->second.first, instance, type, name );
-            }
-            friend std::ostream& operator<<( std::ostream& s,
-                const counter_child& c )
-            {
-                return s << c.child_;
-            }
+			class counter_child
+			{
+			public:
+				counter_child(parents_t& parents, const void* p)
+					: parents_(&parents)
+					, it_(parents.insert(
+						std::make_pair(p, parents_t::mapped_type())).first)
+				{
+					++it_->second.second;
+				}
+				counter_child(const counter_child& rhs)
+					: parents_(rhs.parents_)
+					, it_(rhs.it_)
+					, child_(rhs.child_)
+				{
+					++it_->second.second;
+				}
+				~counter_child()
+				{
+					if (--it_->second.second == 0)
+						parents_->erase(it_);
+				}
+				void update(boost::unit_test::const_string instance,
+					boost::optional< type_name > type,
+					boost::unit_test::const_string name)
+				{
+					child_.update(it_->second.first, instance, type, name);
+				}
+				friend std::ostream& operator<<(std::ostream& s,
+					const counter_child& c)
+				{
+					return s << c.child_;
+				}
 
-        private:
-            counter_child& operator=( const counter_child& );
+			private:
+				counter_child& operator=(const counter_child&);
 
-            parents_t* parents_;
-            parents_t::iterator it_;
-            child child_;
-        };
+				parents_t* parents_;
+				parents_t::iterator it_;
+				child child_;
+			};
 
-        typedef std::map< const verifiable*, counter_child > children_t;
-        typedef children_t::const_iterator children_cit;
+			typedef std::map< const verifiable*, counter_child > children_t;
+			typedef children_t::const_iterator children_cit;
 
-        parents_t parents_;
-        children_t children_;
-        group group_;
-        mutable mutex mutex_;
+			parents_t parents_;
+			children_t children_;
+			group group_;
+			mutable mutex mutex_;
 
-    private:
-        BOOST_TEST_SINGLETON_CONS( root_t );
-    };
-    BOOST_TEST_SINGLETON_INST( root )
-}
+		private:
+			MOCK_SINGLETON_CONS(root_t);
+		};
+		MOCK_SINGLETON_INST(root)
+	}
 } // mock
 
 #endif // MOCK_ROOT_HPP_INCLUDED

--- a/include/turtle/detail/singleton.hpp
+++ b/include/turtle/detail/singleton.hpp
@@ -12,8 +12,8 @@
 //  Description : simple helpers for creating cusom output manipulators
 // ***************************************************************************
 
-#ifndef MOCK_UTILS_TRIVIAL_SIGNLETON_HPP
-#define MOCK_UTILS_TRIVIAL_SIGNLETON_HPP
+#ifndef MOCK_UTILS_TRIVIAL_SINGLETON_HPP
+#define MOCK_UTILS_TRIVIAL_SINGLETON_HPP
 
 // Boost.Test
 #include <boost/config.hpp>
@@ -76,5 +76,5 @@ namespace { BOOST_JOIN( inst, _t)& inst = BOOST_JOIN( inst, _t)::instance(); }
 
 #include <boost/test/detail/enable_warnings.hpp>
 
-#endif // MOCK_UTILS_TRIVIAL_SIGNLETON_HPP
+#endif // MOCK_UTILS_TRIVIAL_SINGLETON_HPP
 

--- a/include/turtle/detail/singleton.hpp
+++ b/include/turtle/detail/singleton.hpp
@@ -1,0 +1,80 @@
+//  (C) Copyright Gennadiy Rozental 2005-2014.
+//  Distributed under the Boost Software License, Version 1.0.
+//  (See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org/libs/test for the library home page.
+//
+//  File        : $RCSfile$
+//
+//  Version     : $Revision$
+//
+//  Description : simple helpers for creating cusom output manipulators
+// ***************************************************************************
+
+#ifndef MOCK_UTILS_TRIVIAL_SIGNLETON_HPP
+#define MOCK_UTILS_TRIVIAL_SIGNLETON_HPP
+
+// Boost.Test
+#include <boost/config.hpp>
+#include <boost/detail/workaround.hpp>
+
+// Boost
+#include <boost/test/detail/suppress_warnings.hpp>
+
+//____________________________________________________________________________//
+
+namespace boost {
+namespace unit_test {
+
+// ************************************************************************** //
+// **************                   singleton                  ************** //
+// ************************************************************************** //
+
+template<typename Derived>
+class singleton {
+public:
+    static Derived& instance() { static Derived the_inst; return the_inst; }
+
+    BOOST_DELETED_FUNCTION(singleton(singleton const&))
+    BOOST_DELETED_FUNCTION(singleton& operator=(singleton const&))
+
+protected:
+    BOOST_DEFAULTED_FUNCTION(singleton(), {})
+    BOOST_DEFAULTED_FUNCTION(~singleton(), {})
+};
+
+//____________________________________________________________________________//
+
+#define MOCK_SINGLETON_CONS( type )       \
+friend class boost::unit_test::singleton<type>; \
+type() {}                                       \
+/**/
+
+#if BOOST_WORKAROUND(__DECCXX_VER, BOOST_TESTED_AT(60590042))
+
+#define MOCK_SINGLETON_INST( inst ) \
+template class unit_test::singleton< BOOST_JOIN( inst, _t ) > ; \
+namespace { BOOST_JOIN( inst, _t)& inst = BOOST_JOIN( inst, _t)::instance(); }
+
+#elif defined(__APPLE_CC__) && defined(__GNUC__) && __GNUC__ < 4
+#define MOCK_SINGLETON_INST( inst ) \
+static BOOST_JOIN( inst, _t)& inst = BOOST_JOIN (inst, _t)::instance();
+
+#else
+
+#define MOCK_SINGLETON_INST( inst ) \
+namespace { BOOST_JOIN( inst, _t)& inst = BOOST_JOIN( inst, _t)::instance(); }
+
+#endif
+
+//____________________________________________________________________________//
+
+} // namespace unit_test
+} // namespace boost
+
+
+#include <boost/test/detail/enable_warnings.hpp>
+
+#endif // MOCK_UTILS_TRIVIAL_SIGNLETON_HPP
+


### PR DESCRIPTION
Solution of missing boost/test/utils/trivial_singleton.hpp from issue #50 
It create singleton.hpp in turtle/include/turtle/detail which replace trivial_singleton.hpp from boost library