### PR TITLE
Use boost-local for boost folder to ignore its coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ before_install:
     # Cloning Boost libraries (fast nondeep cloning)
     - PROJECT_DIR=`pwd`
     - git --version
-    - BOOST=$HOME/boost
+    - BOOST=$HOME/boost-local
     - git clone -b $BRANCH_TO_TEST https://github.com/boostorg/boost.git $BOOST
     - cd $BOOST
     - git submodule update --init --merge


### PR DESCRIPTION
See title.

Found this here: https://coveralls.io/builds/20177313 where coverage decreased a lot although that is only in the checked-out boost folder