### PR TITLE
Implement and use simple singleton

### DIFF
--- a/include/turtle/detail/functor.hpp
+++ b/include/turtle/detail/functor.hpp
@@ -12,19 +12,19 @@
 #include "../config.hpp"
 #include "function.hpp"
 #include "mutex.hpp"
+#include "singleton.hpp"
 
 namespace mock
 {
 namespace detail
 {
     class functor_mutex_t :
-        public boost::unit_test::singleton< functor_mutex_t >,
+        public singleton< functor_mutex_t >,
         public mutex
     {
-    private:
-        BOOST_TEST_SINGLETON_CONS( functor_mutex_t );
+        MOCK_SINGLETON_CONS( functor_mutex_t );
     };
-    BOOST_TEST_SINGLETON_INST( functor_mutex )
+    MOCK_SINGLETON_INST( functor_mutex )
 
     template< typename Signature >
     struct functor : function< Signature >

--- a/include/turtle/detail/mutex.hpp
+++ b/include/turtle/detail/mutex.hpp
@@ -10,7 +10,7 @@
 #define MOCK_MUTEX_HPP_INCLUDED
 
 #include "../config.hpp"
-#include <boost/test/utils/trivial_singleton.hpp>
+#include "singleton.hpp"
 #include <boost/shared_ptr.hpp>
 
 #ifdef MOCK_THREAD_SAFE
@@ -93,13 +93,12 @@ namespace mock
 {
 namespace detail
 {
-    class error_mutex_t : public boost::unit_test::singleton< error_mutex_t >,
+    class error_mutex_t : public singleton< error_mutex_t >,
         public mutex
     {
-    private:
-        BOOST_TEST_SINGLETON_CONS( error_mutex_t );
+        MOCK_SINGLETON_CONS( error_mutex_t );
     };
-    BOOST_TEST_SINGLETON_INST( error_mutex )
+    MOCK_SINGLETON_INST( error_mutex )
 
 #ifdef BOOST_MSVC
 #   pragma warning( push )

--- a/include/turtle/detail/root.hpp
+++ b/include/turtle/detail/root.hpp
@@ -15,7 +15,7 @@
 #include "context.hpp"
 #include "child.hpp"
 #include "mutex.hpp"
-#include <boost/test/utils/trivial_singleton.hpp>
+#include "singleton.hpp"
 #include <boost/optional.hpp>
 #include <ostream>
 #include <map>
@@ -24,7 +24,7 @@ namespace mock
 {
 namespace detail
 {
-    class root_t : public boost::unit_test::singleton< root_t >, public context
+    class root_t : public singleton< root_t >, public context
     {
     public:
         virtual void add( const void* p, verifiable& v,
@@ -128,10 +128,9 @@ namespace detail
         group group_;
         mutable mutex mutex_;
 
-    private:
-        BOOST_TEST_SINGLETON_CONS( root_t );
+        MOCK_SINGLETON_CONS( root_t );
     };
-    BOOST_TEST_SINGLETON_INST( root )
+    MOCK_SINGLETON_INST( root )
 }
 } // mock
 

--- a/include/turtle/detail/singleton.hpp
+++ b/include/turtle/detail/singleton.hpp
@@ -1,0 +1,46 @@
+// http://turtle.sourceforge.net
+//
+// Copyright Mathieu Champlon 2014
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef MOCK_SINGLETON_HPP
+#define MOCK_SINGLETON_HPP
+
+#include <boost/config.hpp>
+
+namespace mock {
+namespace detail {
+
+template< typename Derived >
+class singleton {
+public:
+    static Derived& instance()
+    {
+        static Derived the_inst;
+        return the_inst;
+    }
+
+    BOOST_DELETED_FUNCTION(singleton(singleton const&))
+    BOOST_DELETED_FUNCTION(singleton& operator=(singleton const&))
+
+protected:
+    BOOST_DEFAULTED_FUNCTION(singleton(), {})
+    BOOST_DEFAULTED_FUNCTION(~singleton(), {})
+};
+
+} // detail
+} // mock
+
+// Add a private ctor to the type to prevent misuse
+#define MOCK_SINGLETON_CONS( type )           \
+private:                                      \
+friend class mock::detail::singleton< type >; \
+type() {}
+
+#define MOCK_SINGLETON_INST( inst ) \
+static BOOST_JOIN( inst, _t )& inst = BOOST_JOIN( inst, _t )::instance();
+
+#endif // MOCK_SINGLETON_HPP

--- a/test/mock_error.hpp
+++ b/test/mock_error.hpp
@@ -10,12 +10,12 @@
 #define MOCK_TEST_MOCK_ERROR_HPP_INCLUDED
 
 #define MOCK_ERROR_POLICY mock_error
+#include <turtle/detail/singleton.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/test/utils/trivial_singleton.hpp>
 #include <stdexcept>
 
-struct mock_error_data_t : boost::unit_test::singleton< mock_error_data_t >
+struct mock_error_data_t : mock::detail::singleton< mock_error_data_t >
 {
     void reset()
     {
@@ -52,10 +52,9 @@ struct mock_error_data_t : boost::unit_test::singleton< mock_error_data_t >
     std::string last_context;
     std::string last_file;
     int last_line;
-private:
-    BOOST_TEST_SINGLETON_CONS( mock_error_data_t );
+    MOCK_SINGLETON_CONS( mock_error_data_t );
 };
-BOOST_TEST_SINGLETON_INST( mock_error_data )
+MOCK_SINGLETON_INST( mock_error_data )
 
 template< typename Result >
 struct mock_error


### PR DESCRIPTION
Based on old boost::unit_test::singleton

This is now very similar to #51 as interface and usage is the same. While #55 seems to be the better approach as it avoids a global instance variable it is hard to get the initialization/destruction order right.

Problem: `function_impl` stores a pointer to a `context` and removes itself from there on destruction: https://github.com/mat007/turtle/blob/d77aad128cf6fd9688641bff093637dba7ef5028/include/turtle/detail/function_impl_template.hpp#L64

This fails (crashes) when the context gets destroyed before the function_impl as it may happen for a singleton context (`root_t`) and global mocked functions.

As this problem is a different one and hard(er) to solve, Boost 1.68 compatibility is achieved with this.