### PR TITLE
Fix gnu-zero-variadic-macro-arguments warning

### DIFF
--- a/include/turtle/mock.hpp
+++ b/include/turtle/mock.hpp
@@ -21,6 +21,7 @@
 #include "detail/parameter.hpp"
 #include <boost/preprocessor/repetition/repeat.hpp>
 #include <boost/preprocessor/stringize.hpp>
+#include <boost/preprocessor/variadic/elem.hpp>
 #include <boost/utility/identity_type.hpp>
 #include <boost/mpl/assert.hpp>
 
@@ -179,53 +180,49 @@
 
 #ifdef MOCK_VARIADIC_MACROS
 
-#define MOCK_VARIADIC_ELEM_0(e0, ...) e0
-#define MOCK_VARIADIC_ELEM_1(e0, e1, ...) e1
-#define MOCK_VARIADIC_ELEM_2(e0, e1, e2, ...) e2
-
 #define MOCK_METHOD(M, ...) \
     MOCK_METHOD_EXT(M, \
-        MOCK_VARIADIC_ELEM_0(__VA_ARGS__ ), \
-        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, MOCK_SIGNATURE(M)), \
-        MOCK_VARIADIC_ELEM_2(__VA_ARGS__, M, M))
+        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__ ), \
+        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, MOCK_SIGNATURE(M)), \
+        BOOST_PP_VARIADIC_ELEM(2, __VA_ARGS__, M, M))
 #define MOCK_CONST_METHOD(M, n, ...) \
     MOCK_CONST_METHOD_EXT(M, n, \
-        MOCK_VARIADIC_ELEM_0(__VA_ARGS__), \
-        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, M))
+        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
+        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, M))
 #define MOCK_NON_CONST_METHOD(M, n, ...) \
     MOCK_NON_CONST_METHOD_EXT(M, n, \
-        MOCK_VARIADIC_ELEM_0(__VA_ARGS__), \
-        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, M))
+        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
+        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, M))
 
 #define MOCK_METHOD_TPL(M, n, ...) \
     MOCK_METHOD_EXT_TPL(M, n, \
-        MOCK_VARIADIC_ELEM_0(__VA_ARGS__), \
-        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, M))
+        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
+        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, M))
 #define MOCK_CONST_METHOD_TPL(M, n, ...) \
     MOCK_CONST_METHOD_EXT_TPL(M, n, \
-        MOCK_VARIADIC_ELEM_0(__VA_ARGS__), \
-        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, M))
+        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
+        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, M))
 #define MOCK_NON_CONST_METHOD_TPL(M, n, ...) \
     MOCK_NON_CONST_METHOD_EXT_TPL(M, n, \
-        MOCK_VARIADIC_ELEM_0(__VA_ARGS__), \
-        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, M))
+        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
+        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, M))
 
 #define MOCK_FUNCTION(F, n, ...) \
     MOCK_FUNCTION_AUX(F, n, \
-        MOCK_VARIADIC_ELEM_0(__VA_ARGS__), \
-        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, F), \
+        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
+        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, F), \
         inline,)
 
 #define MOCK_STATIC_METHOD(F, n, ...) \
     MOCK_FUNCTION_AUX(F, n, \
-        MOCK_VARIADIC_ELEM_0(__VA_ARGS__), \
-        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, F), \
+        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
+        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, F), \
         static,)
 
 #define MOCK_STATIC_METHOD_TPL(F, n, ...) \
     MOCK_FUNCTION_AUX(F, n, \
-        MOCK_VARIADIC_ELEM_0(__VA_ARGS__), \
-        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, F), \
+        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
+        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, F), \
         static, typename)
 
 #else // MOCK_VARIADIC_MACROS

--- a/include/turtle/mock.hpp
+++ b/include/turtle/mock.hpp
@@ -21,7 +21,6 @@
 #include "detail/parameter.hpp"
 #include <boost/preprocessor/repetition/repeat.hpp>
 #include <boost/preprocessor/stringize.hpp>
-#include <boost/preprocessor/variadic/elem.hpp>
 #include <boost/utility/identity_type.hpp>
 #include <boost/mpl/assert.hpp>
 
@@ -180,49 +179,53 @@
 
 #ifdef MOCK_VARIADIC_MACROS
 
+#define MOCK_VARIADIC_ELEM_0(e0, ...) e0
+#define MOCK_VARIADIC_ELEM_1(e0, e1, ...) e1
+#define MOCK_VARIADIC_ELEM_2(e0, e1, e2, ...) e2
+
 #define MOCK_METHOD(M, ...) \
     MOCK_METHOD_EXT(M, \
-        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__ ), \
-        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, MOCK_SIGNATURE(M)), \
-        BOOST_PP_VARIADIC_ELEM(2, __VA_ARGS__, M, M))
+        MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), \
+        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, MOCK_SIGNATURE(M), ), \
+        MOCK_VARIADIC_ELEM_2(__VA_ARGS__, M, M, ))
 #define MOCK_CONST_METHOD(M, n, ...) \
     MOCK_CONST_METHOD_EXT(M, n, \
-        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
-        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, M))
+        MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), \
+        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, M, ))
 #define MOCK_NON_CONST_METHOD(M, n, ...) \
     MOCK_NON_CONST_METHOD_EXT(M, n, \
-        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
-        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, M))
+        MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), \
+        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, M, ))
 
 #define MOCK_METHOD_TPL(M, n, ...) \
     MOCK_METHOD_EXT_TPL(M, n, \
-        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
-        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, M))
+        MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), \
+        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, M, ))
 #define MOCK_CONST_METHOD_TPL(M, n, ...) \
     MOCK_CONST_METHOD_EXT_TPL(M, n, \
-        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
-        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, M))
+        MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), \
+        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, M, ))
 #define MOCK_NON_CONST_METHOD_TPL(M, n, ...) \
     MOCK_NON_CONST_METHOD_EXT_TPL(M, n, \
-        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
-        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, M))
+        MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), \
+        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, M, ))
 
 #define MOCK_FUNCTION(F, n, ...) \
     MOCK_FUNCTION_AUX(F, n, \
-        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
-        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, F), \
+        MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), \
+        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, F, ), \
         inline,)
 
 #define MOCK_STATIC_METHOD(F, n, ...) \
     MOCK_FUNCTION_AUX(F, n, \
-        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
-        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, F), \
+        MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), \
+        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, F, ), \
         static,)
 
 #define MOCK_STATIC_METHOD_TPL(F, n, ...) \
     MOCK_FUNCTION_AUX(F, n, \
-        BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__), \
-        BOOST_PP_VARIADIC_ELEM(1, __VA_ARGS__, F), \
+        MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), \
+        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, F, ), \
         static, typename)
 
 #else // MOCK_VARIADIC_MACROS


### PR DESCRIPTION
Clang 5.0 throws a warning 

> error: must specify at least one argument for '...' parameter of variadic macro [-Werror,-Wgnu-zero-variadic-macro-arguments]

due to usage of `MOCK_VARIADIC_ELEM_<N>`. 

This issue is critical as it generates warnings in client code which cannot be avoided with `-isystem`!

This PR adds a trailing comma which fixes the warning.

Note: `BOOST_PP_VARIADIC_ELEM` could be used in C++11. I left the commit in so the 2nd commit could simply be reverted when switching to C++11

Note: What about doing CI with `-Werror`? -> #64