### PR TITLE
Fix documentation regarding protected methods

### DIFF
--- a/doc/example/limitations_protected_private_method.cpp
+++ b/doc/example/limitations_protected_private_method.cpp
@@ -15,7 +15,7 @@ namespace
 //[ limitations_protected_private_method_problem
     class base
     {
-    private:
+    protected:
         virtual void method_1() = 0;
     private:
         virtual void method_2() = 0;

--- a/doc/limitations.qbk
+++ b/doc/limitations.qbk
@@ -112,7 +112,7 @@ A workaround would be to add the signature to MOCK_METHOD :
 
 [endsect]
 
-[section Private virtual methods cannot be mocked without specifying the signature]
+[section Protected and private virtual methods cannot be mocked without specifying the signature]
 
 Given :
 


### PR DESCRIPTION
In a previous commit, the workaround for private methods was extended towards protected methods, but the changes were inconsistent.