### PR TITLE
Remove boost deprecations

### DIFF
--- a/include/turtle/config.hpp
+++ b/include/turtle/config.hpp
@@ -101,4 +101,13 @@
 #   endif
 #endif
 
+#if BOOST_VERSION >= 107000
+#   define MOCK_TYPEID( t ) BOOST_CORE_TYPEID(t)
+#   define MOCK_TYPEINFO boost::core::typeinfo
+#else
+#   define MOCK_TYPEID( t ) BOOST_SP_TYPEID(t)
+#   define MOCK_TYPEINFO boost::detail::sp_typeinfo
+#endif
+
+
 #endif // MOCK_CONFIG_HPP_INCLUDED

--- a/include/turtle/constraints.hpp
+++ b/include/turtle/constraints.hpp
@@ -19,7 +19,11 @@
 #include <boost/type_traits/common_type.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/has_equal_to.hpp>
+#if BOOST_VERSION >= 107000
+#include <boost/test/tools/floating_point_comparison.hpp>
+#else
 #include <boost/test/floating_point_comparison.hpp>
+#endif
 
 namespace mock
 {

--- a/include/turtle/detail/type_name.hpp
+++ b/include/turtle/detail/type_name.hpp
@@ -28,15 +28,7 @@
 #include <cstdlib>
 #endif
 
-#if BOOST_VERSION >= 107000
-#define MOCK_TYPE_ID( t ) BOOST_CORE_TYPEID(t)
-#define TYPEINFO boost::core::typeinfo
-#else
-#define MOCK_TYPE_ID( t ) BOOST_SP_TYPEID(t)
-#define TYPEINFO boost::detail::sp_typeinfo
-#endif
-
-#define MOCK_TYPE_NAME( t ) mock::detail::type_name( MOCK_TYPE_ID(t) )
+#define MOCK_TYPE_NAME( t ) mock::detail::type_name( MOCK_TYPEID(t) )
 
 namespace mock
 {
@@ -45,7 +37,7 @@ namespace detail
     class type_name
     {
     public:
-        explicit type_name( const TYPEINFO& info )
+        explicit type_name( const MOCK_TYPEINFO& info )
             : info_( &info )
         {}
         friend std::ostream& operator<<( std::ostream& s, const type_name& t )
@@ -55,7 +47,7 @@ namespace detail
         }
     private:
         void serialize( std::ostream& s,
-            const TYPEINFO& info ) const
+            const MOCK_TYPEINFO& info ) const
         {
             const char* name = info.name();
 #ifdef __GNUC__
@@ -120,7 +112,7 @@ namespace detail
             return std::string::npos;
         }
 
-        const TYPEINFO* info_;
+        const MOCK_TYPEINFO* info_;
     };
 }
 } // mock

--- a/include/turtle/detail/type_name.hpp
+++ b/include/turtle/detail/type_name.hpp
@@ -14,7 +14,11 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/erase.hpp>
 #include <boost/algorithm/string/trim.hpp>
+#if BOOST_VERSION >= 107000
+#include <boost/core/typeinfo.hpp>
+#else
 #include <boost/detail/sp_typeinfo.hpp>
+#endif
 #include <boost/shared_ptr.hpp>
 #include <stdexcept>
 #include <typeinfo>
@@ -24,7 +28,15 @@
 #include <cstdlib>
 #endif
 
-#define MOCK_TYPE_NAME( t ) mock::detail::type_name( BOOST_SP_TYPEID(t) )
+#if BOOST_VERSION >= 107000
+#define MOCK_TYPE_ID( t ) BOOST_CORE_TYPEID(t)
+#define TYPEINFO boost::core::typeinfo
+#else
+#define MOCK_TYPE_ID( t ) BOOST_SP_TYPEID(t)
+#define TYPEINFO boost::detail::sp_typeinfo
+#endif
+
+#define MOCK_TYPE_NAME( t ) mock::detail::type_name( MOCK_TYPE_ID(t) )
 
 namespace mock
 {
@@ -33,7 +45,7 @@ namespace detail
     class type_name
     {
     public:
-        explicit type_name( const boost::detail::sp_typeinfo& info )
+        explicit type_name( const TYPEINFO& info )
             : info_( &info )
         {}
         friend std::ostream& operator<<( std::ostream& s, const type_name& t )
@@ -43,7 +55,7 @@ namespace detail
         }
     private:
         void serialize( std::ostream& s,
-            const boost::detail::sp_typeinfo& info ) const
+            const TYPEINFO& info ) const
         {
             const char* name = info.name();
 #ifdef __GNUC__
@@ -108,7 +120,7 @@ namespace detail
             return std::string::npos;
         }
 
-        const boost::detail::sp_typeinfo* info_;
+        const TYPEINFO* info_;
     };
 }
 } // mock


### PR DESCRIPTION
Fixes:

boost/test/floating_point_comparison.hpp:14:124: note: #pragma message: This header is deprecated. Use This header is deprecated. Please use <boost/test/tools/floating_point_comparison.hpp> instead. instead.
boost/detail/sp_typeinfo.hpp:23:54: note: #pragma message: This header is deprecated. Use <boost/core/typeinfo.hpp> instead.