### PR TITLE
Add CMake files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin
 out
 build/xsl
+__build

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,12 @@ script:
     - export BOOST_ROOT=$BOOST
     # `--coverage` flags required to generate coverage info for Coveralls
     - ./build.sh --toolset=$CC "cxxflags=-std=$CXX_STANDARD -Wno-unused-local-typedefs -Wno-unused-function -Wno-deprecated-declarations --coverage" "linkflags=--coverage"
+    - cd $BOOST && ./b2 --with-test --with-thread --with-chrono --with-system --with-atomic --with-date_time -a -j3 # Build required libs
+    - mkdir $PROJECT_DIR/__build && cd $PROJECT_DIR/__build
+    - export CXXFLAGS="-std=$CXX_STANDARD -Wall -Wextra"
+    - cmake .. -DCMAKE_BUILD_TYPE=Debug
+    - cmake --build . --config Debug
+    - ctest --output-on-failure --build-config Debug
 
 after_success:
     - COVERALS_DIR=$PROJECT_DIR/coverals

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,14 +87,14 @@ after_success:
 
     # Copying Coveralls data to a separate folder
     - mkdir -p $COVERALS_DIR
-    - find ../test/bin/ -name "*.gcda" -exec cp "{}" $COVERALS_DIR/ \;
-    - find ../test/bin/ -name "*.gcno" -exec cp "{}" $COVERALS_DIR/ \;
+    - find $PROJECT_DIR/test/bin/ -name "*.gcda" -exec cp "{}" $COVERALS_DIR/ \;
+    - find $PROJECT_DIR/test/bin/ -name "*.gcno" -exec cp "{}" $COVERALS_DIR/ \;
 
     # Preparing Coveralls data by
     # ... installing the tools
     - sudo apt-get install -qq python-yaml lcov
     # ... changing data format to a readable one
-    - lcov --directory $COVERALS_DIR --base-directory /home/travis/build/mat007/turtle/test --capture --output-file $COVERALS_DIR/coverage.info
+    - lcov --directory $COVERALS_DIR --base-directory $PROJECT_DIR/test --capture --output-file $COVERALS_DIR/coverage.info
 
     # ... erasing /test/ /example/ folder data
     - lcov --remove $COVERALS_DIR/coverage.info "/usr*" "/test/*" $IGNORE_COVERAGE "tests/*" "*/doc/examples/*" -o $COVERALS_DIR/coverage.info
@@ -102,4 +102,4 @@ after_success:
     # Sending data to Coveralls
     - cd $PROJECT_DIR
     - gem install coveralls-lcov
-    - coveralls-lcov coverals/coverage.info
+    - coveralls-lcov $COVERALS_DIR/coverage.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,8 @@ after_success:
 
     # ... erasing /test/ /example/ folder data
     - lcov --remove $COVERALS_DIR/coverage.info "/usr*" "/test/*" $IGNORE_COVERAGE "tests/*" "*/doc/examples/*" -o $COVERALS_DIR/coverage.info
+    # Output what was collected
+    - lcov --list $COVERALS_DIR/coverage.info
 
     # Sending data to Coveralls
     - cd $PROJECT_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,79 @@
+# Copyright 2019 Alexander Grund
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.8)
+project(turtle VERSION 1.3.2 LANGUAGES CXX)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(IS_ROOT_PROJECT ON)
+  include(CTest)
+else()
+  set(IS_ROOT_PROJECT OFF)
+endif()
+
+option(TURTLE_INSTALL "Enable to add install target" ${IS_ROOT_PROJECT})
+option(TURTLE_AUTO_PTR "Enable support for auto_ptr" OFF)
+
+# Default boost libs are static on windows and dynamic on linux
+if(WIN32 AND NOT DEFINED Boost_USE_STATIC_LIBS)
+  set(Boost_USE_STATIC_LIBS ON)
+endif()
+find_package(Boost 1.58 REQUIRED)
+
+set(MOCK_VERSION "\"${PROJECT_VERSION}\"")
+configure_file(build/version.hpp ${CMAKE_CURRENT_BINARY_DIR}/include/turtle/version.hpp @ONLY)
+
+add_library(turtle INTERFACE)
+add_library(turtle::turtle ALIAS turtle)
+target_include_directories(turtle INTERFACE $<BUILD_INTERFACE:include;${CMAKE_CURRENT_BINARY_DIR}/include>)
+target_link_libraries(turtle INTERFACE Boost::boost Boost::disable_autolinking)
+if(NOT TURTLE_AUTO_PTR)
+  target_compile_definitions(turtle INTERFACE MOCK_NO_AUTO_PTR)
+endif()
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
+
+if(TURTLE_INSTALL)
+  include(GNUInstallDirs)
+  include(CMakePackageConfigHelpers)
+
+  target_include_directories(turtle INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+  install(TARGETS turtle
+    EXPORT ${PROJECT_NAME}Targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+  install(DIRECTORY include/ ${CMAKE_CURRENT_BINARY_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+  set(configFile ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake)
+  set(versionFile ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake)
+  set(configInstallDestination lib/cmake/${PROJECT_NAME})
+
+  configure_package_config_file(
+    ${PROJECT_SOURCE_DIR}/Config.cmake.in
+    ${configFile} 
+    INSTALL_DESTINATION ${configInstallDestination}
+  )
+
+  if(NOT CMAKE_VERSION VERSION_LESS 3.14)
+    write_basic_package_version_file(${versionFile} COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
+  else()
+    set(OLD_CMAKE_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
+    set(CMAKE_SIZEOF_VOID_P "")
+    write_basic_package_version_file(${versionFile} COMPATIBILITY SameMajorVersion)
+    set(CMAKE_SIZEOF_VOID_P ${OLD_CMAKE_SIZEOF_VOID_P})
+  endif()
+
+  install(FILES ${configFile} ${versionFile} DESTINATION ${configInstallDestination})
+
+  install(
+    EXPORT ${PROJECT_NAME}Targets
+    NAMESPACE "turtle::"
+    DESTINATION ${configInstallDestination}
+  )
+endif()

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Boost 1.58)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+
+check_required_components("@PROJECT_NAME@")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Copyright 2019 Alexander Grund
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+find_package(Boost 1.58 REQUIRED COMPONENTS unit_test_framework thread)
+
+add_library(TurtleTestMain STATIC main.cpp)
+target_link_libraries(TurtleTestMain PUBLIC Boost::unit_test_framework Boost::disable_autolinking)
+# Heuristically guess if we are compiling against dynamic boost
+if(NOT Boost_USE_STATIC_LIBS AND Boost_UNIT_TEST_FRAMEWORK_LIBRARY AND NOT Boost_UNIT_TEST_FRAMEWORK_LIBRARY MATCHES "\\${CMAKE_STATIC_LIBRARY_SUFFIX}\$")
+    target_compile_definitions(TurtleTestMain PUBLIC BOOST_TEST_DYN_LINK)
+endif()
+
+file(GLOB_RECURSE testFiles test_*.cpp)
+set(testsUsingUndefinedCPP test_function test_integration)
+foreach(testFile IN LISTS testFiles)
+  get_filename_component(name ${testFile} NAME_WE)
+
+  foreach(testVariant IN ITEMS "" _max_args _use_conversions _no_decltype _no_variadic_macros _thread_safe)
+    set(curName ${name}${testVariant})
+    add_executable(${curName} ${testFile})
+    if(name IN_LIST testsUsingUndefinedCPP)
+      target_sources(${curName} PRIVATE undefined.cpp)
+    endif()
+    target_link_libraries(${curName} PRIVATE turtle::turtle TurtleTestMain)
+    add_test(NAME ${curName} COMMAND ${curName})
+  endforeach()
+
+  target_compile_definitions(${name}_max_args PRIVATE MOCK_MAX_ARGS=21)
+  target_compile_definitions(${name}_use_conversions PRIVATE MOCK_USE_CONVERSIONS)
+  target_compile_definitions(${name}_no_decltype PRIVATE MOCK_NO_DECLTYPE)
+  target_compile_definitions(${name}_no_variadic_macros PRIVATE MOCK_NO_VARIADIC_MACROS)
+
+  target_link_libraries(${name}_thread_safe PRIVATE Boost::thread)
+  target_compile_definitions(${name}_thread_safe PRIVATE MOCK_THREAD_SAFE BOOST_THREAD_USES_MOVE)
+endforeach()
+
+add_executable(link-test_defined EXCLUDE_FROM_ALL defined_1.cpp defined_2.cpp)
+target_link_libraries(link-test_defined PRIVATE turtle::turtle TurtleTestMain)
+add_test(NAME link-test_defined COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target link-test_defined --config $<CONFIG>)
+
+file(GLOB_RECURSE compileFailureTestFiles fail_*.cpp)
+foreach(testFile IN LISTS compileFailureTestFiles)
+  get_filename_component(name ${testFile} NAME_WE)
+
+  add_library(${name} STATIC EXCLUDE_FROM_ALL ${testFile})
+  target_link_libraries(${name} turtle::turtle)
+  add_test(NAME compile-${name} COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${name} --config $<CONFIG>)
+  set_tests_properties(compile-${name} PROPERTIES WILL_FAIL TRUE)
+endforeach()

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,0 +1,10 @@
+// http://turtle.sourceforge.net
+//
+// Copyright Mathieu Champlon 2009
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_AUTO_TEST_MAIN
+#include <boost/test/auto_unit_test.hpp>


### PR DESCRIPTION
This adds a CMake based buildsystem which is able to compile, test and install Turtle. As mentioned in #78 the BoostBook stuff is missing. Not sure if this can be made cross-platform in CMake

It also tests it on travis, appveyor can be added.

With this included the MSVC projects in `build` can be removed as they easily become out of date.

Note that I define `MOCK_NO_AUTO_PTR` unless explicitly requested. Nobody should be using that nowadays...

Closes #78