### PR TITLE
Auto-deduce method sig in MOCK_METHOD_(NON)CONST

### DIFF
--- a/include/turtle/mock.hpp
+++ b/include/turtle/mock.hpp
@@ -188,14 +188,16 @@
         MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), \
         MOCK_VARIADIC_ELEM_1(__VA_ARGS__, MOCK_SIGNATURE(M), ), \
         MOCK_VARIADIC_ELEM_2(__VA_ARGS__, M, M, ))
-#define MOCK_CONST_METHOD(M, n, ...) \
-    MOCK_CONST_METHOD_EXT(M, n, \
+#define MOCK_CONST_METHOD(M, ...) \
+    MOCK_CONST_METHOD_EXT(M, \
         MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), \
-        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, M, ))
-#define MOCK_NON_CONST_METHOD(M, n, ...) \
-    MOCK_NON_CONST_METHOD_EXT(M, n, \
+        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, MOCK_SIGNATURE(M), ), \
+        MOCK_VARIADIC_ELEM_2(__VA_ARGS__, M, M, ))
+#define MOCK_NON_CONST_METHOD(M, ...) \
+    MOCK_NON_CONST_METHOD_EXT(M, \
         MOCK_VARIADIC_ELEM_0(__VA_ARGS__, ), \
-        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, M, ))
+        MOCK_VARIADIC_ELEM_1(__VA_ARGS__, MOCK_SIGNATURE(M), ), \
+        MOCK_VARIADIC_ELEM_2(__VA_ARGS__, M, M, ))
 
 #define MOCK_METHOD_TPL(M, n, ...) \
     MOCK_METHOD_EXT_TPL(M, n, \

--- a/test/test_mock.cpp
+++ b/test/test_mock.cpp
@@ -366,6 +366,8 @@ namespace
         {}
 
         virtual void m1() = 0;
+        virtual void m10() const = 0;
+        virtual void m11() = 0;
     };
 
     MOCK_BASE_CLASS( variadic, base )
@@ -373,8 +375,10 @@ namespace
         MOCK_METHOD( m1, 0 )
         MOCK_METHOD( m2, 0, void() )
         MOCK_METHOD( m3, 0, void(), m3 )
+        MOCK_CONST_METHOD( m10, 0 )
         MOCK_CONST_METHOD( m4, 0, void() )
         MOCK_CONST_METHOD( m5, 0, void(), m5 )
+        MOCK_NON_CONST_METHOD( m11, 0 )
         MOCK_NON_CONST_METHOD( m6, 0, void() )
         MOCK_NON_CONST_METHOD( m7, 0, void(), m7 )
         MOCK_STATIC_METHOD( m8, 0, void() )


### PR DESCRIPTION
Uses the same form as `MOCK_METHOD`

Fixes #93