### PR TITLE
Fix root path of coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
         with:
           path-to-lcov: ${{env.PROJECT_DIR}}/coverage.info
           github-token: ${{secrets.GITHUB_TOKEN}}
+          base-path: ${{env.PROJECT_DIR}}
 
       - name: Build required boost libs
         working-directory: boost-root


### PR DESCRIPTION
The repo files were moved to a subfolder which confuses the coverage UI

Setting the base-path allows to keep the sources in the subfolder of the default checkout folder.

Note: The subfolder was required because we need to put BOOST_ROOT somewhere and only the PROJECT folder is guaranteed to be writeable.

See e.g. https://coveralls.io/builds/46260109/source?filename=repo%2Finclude%2Fturtle%2Fcleanup.hpp for an example of the issue