### PR TITLE
Fix issue 115 null c string derefs

### DIFF
--- a/include/turtle/matcher.hpp
+++ b/include/turtle/matcher.hpp
@@ -41,7 +41,7 @@ public:
     explicit matcher(const char* expected) : expected_(expected) {}
     bool operator()(const char* actual)
     {
-        if (nullptr == actual || nullptr == expected_)
+        if(!actual || !expected_)
             return actual == expected_;
         return std::strcmp(actual, expected_) == 0;
     }

--- a/include/turtle/matcher.hpp
+++ b/include/turtle/matcher.hpp
@@ -39,7 +39,12 @@ class matcher<const char*, const char*>
 {
 public:
     explicit matcher(const char* expected) : expected_(expected) {}
-    bool operator()(const char* actual) { return std::strcmp(actual, expected_) == 0; }
+    bool operator()(const char* actual)
+    {
+        if (nullptr == actual || nullptr == expected_)
+            return actual == expected_;
+        return std::strcmp(actual, expected_) == 0;
+    }
     friend std::ostream& operator<<(std::ostream& s, const matcher& m) { return s << mock::format(m.expected_); }
 
 private:

--- a/include/turtle/stream.hpp
+++ b/include/turtle/stream.hpp
@@ -108,7 +108,7 @@ namespace detail {
     }
     inline void serialize(stream& s, const char* const str)
     {
-        if (nullptr != str)
+        if(str)
             s << '"' << str << '"';
         else
             s << "nullptr";

--- a/include/turtle/stream.hpp
+++ b/include/turtle/stream.hpp
@@ -106,7 +106,13 @@ namespace detail {
     {
         s << '"' << str << '"';
     }
-    inline void serialize(stream& s, const char* const str) { s << '"' << str << '"'; }
+    inline void serialize(stream& s, const char* const str)
+    {
+        if (nullptr != str)
+            s << '"' << str << '"';
+        else
+            s << "nullptr";
+    }
     inline void serialize(stream& s, unsigned char c) { s << static_cast<int>(c); }
 } // namespace detail
 } // namespace mock

--- a/test/test_constraints.cpp
+++ b/test/test_constraints.cpp
@@ -80,6 +80,15 @@ BOOST_AUTO_TEST_CASE(equal_constraint_deref)
     }
 }
 
+BOOST_AUTO_TEST_CASE(equal_null_c_string)
+{
+    const char* const null_str = nullptr;
+
+    BOOST_CHECK(mock::equal(null_str).c_(null_str));
+    BOOST_CHECK(!mock::equal(null_str).c_("non-null string"));
+    BOOST_CHECK(!mock::equal("non-null-string").c_(null_str));
+}
+
 BOOST_AUTO_TEST_CASE(same_constraint)
 {
     {

--- a/test/test_log.cpp
+++ b/test/test_log.cpp
@@ -89,6 +89,14 @@ BOOST_AUTO_TEST_CASE(strings_are_serialized_with_double_quotes)
     BOOST_CHECK_EQUAL("\"string\"", to_string(std::string("string")));
 }
 
+BOOST_AUTO_TEST_CASE(null_c_strings_are_serialized_to_nullptr)
+{
+    const char* const null_str = nullptr;
+    BOOST_CHECK_EQUAL("nullptr", to_string(null_str));
+    // Note the lack of double quotes in the output, as opposed to when the
+    // string "nullptr" is serialized.
+}
+
 namespace {
 struct non_serializable
 {};

--- a/test/test_log.cpp
+++ b/test/test_log.cpp
@@ -93,8 +93,7 @@ BOOST_AUTO_TEST_CASE(null_c_strings_are_serialized_to_nullptr)
 {
     const char* const null_str = nullptr;
     BOOST_CHECK_EQUAL("nullptr", to_string(null_str));
-    // Note the lack of double quotes in the output, as opposed to when the
-    // string "nullptr" is serialized.
+    BOOST_CHECK_EQUAL("\"nullptr\"", to_string("nullptr"));
 }
 
 namespace {

--- a/test/test_matcher.cpp
+++ b/test/test_matcher.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(ref_to_int_and_int_can_be_compared)
 namespace {
 struct fixture
 {
-    fixture() : text("same text"), actual(text.c_str())
+    fixture() : text("same text"), actual(text.c_str()), null_str(nullptr)
     {
         const char* static_string = "same text";
         BOOST_REQUIRE(actual != static_string);
@@ -44,6 +44,7 @@ struct fixture
     }
     std::string text;
     const char* actual;
+    const char* null_str;
 };
 } // namespace
 
@@ -73,6 +74,13 @@ BOOST_FIXTURE_TEST_CASE(const_char_pointer_and_std_string_can_be_compared, fixtu
 {
     BOOST_CHECK(match(std::string("same text"), actual));
     BOOST_CHECK(!match(std::string("different text"), actual));
+}
+
+BOOST_FIXTURE_TEST_CASE(null_const_char_pointers_can_be_compared, fixture)
+{
+    BOOST_CHECK(match(null_str, null_str));
+    BOOST_CHECK(!match(null_str, "non-null string"));
+    BOOST_CHECK(!match("non-null string", null_str));
 }
 
 namespace {

--- a/test/test_matcher.cpp
+++ b/test/test_matcher.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(ref_to_int_and_int_can_be_compared)
 namespace {
 struct fixture
 {
-    fixture() : text("same text"), actual(text.c_str()), null_str(nullptr)
+    fixture() : text("same text"), actual(text.c_str())
     {
         const char* static_string = "same text";
         BOOST_REQUIRE(actual != static_string);
@@ -44,7 +44,6 @@ struct fixture
     }
     std::string text;
     const char* actual;
-    const char* null_str;
 };
 } // namespace
 
@@ -76,8 +75,9 @@ BOOST_FIXTURE_TEST_CASE(const_char_pointer_and_std_string_can_be_compared, fixtu
     BOOST_CHECK(!match(std::string("different text"), actual));
 }
 
-BOOST_FIXTURE_TEST_CASE(null_const_char_pointers_can_be_compared, fixture)
+BOOST_AUTO_TEST_CASE(null_const_char_pointers_can_be_compared)
 {
+    const char* const null_str = nullptr;
     BOOST_CHECK(match(null_str, null_str));
     BOOST_CHECK(!match(null_str, "non-null string"));
     BOOST_CHECK(!match("non-null string", null_str));


### PR DESCRIPTION
This pull request fixes the cases of `nullptr` dereference when mocking C-style string (`char*`) arguments described in #115. It adds unit tests for the matching and serialization of C-style strings that are in fact `nullptr`. The new unit tests correctly fail before application of the fix, except for the new test of `mock::equal`, which was added merely as a regression test.

Fixes #115