### PR TITLE
Improve use of fixture in test_matcher

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,10 @@ environment:
       CMAKE: true
 
 install:
+  - appveyor-retry powershell Invoke-WebRequest http://www.oasis-open.org/docbook/xml/4.2/docbook-xml-4.2.zip -OutFile docbook-xml.zip
+  - appveyor-retry powershell Invoke-WebRequest https://github.com/docbook/xslt10-stylesheets/releases/download/release/1.79.2/docbook-xsl-1.79.2.zip -OutFile docbook-xsl.zip
+  - 7z x -oC:\Boost\share\docbook-xml docbook-xml.zip
+  - 7z x -oC:\Boost\share docbook-xsl.zip
   - mkdir %APPVEYOR_BUILD_FOLDER%\bin
   - cd %APPVEYOR_BUILD_FOLDER%\bin
   - appveyor-retry powershell Invoke-WebRequest ftp://ftp.zlatkovic.com/libxml/iconv-1.9.2.win32.zip -OutFile iconv.zip

--- a/test/detail/test_function.cpp
+++ b/test/detail/test_function.cpp
@@ -158,6 +158,56 @@ BOOST_FIXTURE_TEST_CASE(triggering_several_once_expectations_is_valid, mock_erro
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(string_likes_are_matched, mock_error_fixture)
+{
+    const char* c_string = "value";
+    const char c_string2[] = "value";
+    BOOST_REQUIRE(c_string != c_string2); // Different pointers
+    const std::string string = c_string;
+    {
+        mock::detail::function<void(std::string)> f;
+
+        f.expect().once().with(string);
+        f(string);
+        BOOST_TEST(f.verify());
+
+        f.reset();
+        f.expect().once().with(c_string);
+        f(string);
+        BOOST_TEST(f.verify());
+
+        f.reset();
+        f.expect().once().with(c_string2);
+        f(string);
+        BOOST_TEST(f.verify());
+
+        CHECK_CALLS(3);
+    }
+    {
+        mock::detail::function<void(const char*)> f;
+
+        f.expect().once().with(c_string);
+        f(c_string);
+        BOOST_TEST(f.verify());
+
+        f.reset();
+        f.expect().once().with(c_string);
+        f(c_string2);
+        BOOST_TEST(f.verify());
+
+        f.reset();
+        f.expect().once().with(c_string2);
+        f(c_string);
+        BOOST_TEST(f.verify());
+
+        f.reset();
+        f.expect().once().with(string);
+        f(c_string);
+        BOOST_TEST(f.verify());
+        CHECK_CALLS(4);
+    }
+}
+
 BOOST_FIXTURE_TEST_CASE(triggering_a_once_expectation_calls_unexpected_call_error_after_one_call, mock_error_fixture)
 {
     {

--- a/test/test_matcher.cpp
+++ b/test/test_matcher.cpp
@@ -33,46 +33,39 @@ BOOST_AUTO_TEST_CASE(ref_to_int_and_int_can_be_compared)
     BOOST_CHECK(!match(4, std::cref(i)));
 }
 
-namespace {
-struct fixture
-{
-    fixture() : text("same text"), actual(text.c_str())
-    {
-        const char* static_string = "same text";
-        BOOST_REQUIRE(actual != static_string);
-        BOOST_REQUIRE(actual == std::string(static_string));
-    }
-    std::string text;
-    const char* actual;
-};
-} // namespace
-
-BOOST_FIXTURE_TEST_CASE(const_char_pointer_and_const_char_pointer_can_be_compared, fixture)
+BOOST_AUTO_TEST_CASE(const_char_pointer_and_const_char_pointer_can_be_compared)
 {
     const char* expected = "same text";
+    const char* actual = "same text";
+    BOOST_REQUIRE(expected != actual); // Different pointer values
     BOOST_CHECK(match(expected, actual));
     const char* unexpected = "different text";
     BOOST_CHECK(!match(actual, unexpected));
 }
 
-BOOST_FIXTURE_TEST_CASE(const_char_pointer_and_string_literal_can_be_compared, fixture)
+BOOST_AUTO_TEST_CASE(const_char_pointer_and_string_literal_can_be_compared)
 {
+    const char* actual = "same text";
     BOOST_CHECK(match("same text", actual));
     BOOST_CHECK(!match("different text", actual));
 }
 
-BOOST_FIXTURE_TEST_CASE(const_char_pointer_and_const_char_array_can_be_compared, fixture)
+BOOST_AUTO_TEST_CASE(const_char_pointer_and_const_char_array_can_be_compared)
 {
-    const char expected[10] = "same text";
+    const char* actual = "same text";
+    const char expected[] = "same text";
     BOOST_CHECK(match(expected, actual));
-    const char unexpected[15] = "different text";
+    const char unexpected[] = "different text";
     BOOST_CHECK(!match(unexpected, actual));
 }
 
-BOOST_FIXTURE_TEST_CASE(const_char_pointer_and_std_string_can_be_compared, fixture)
+BOOST_AUTO_TEST_CASE(const_char_pointer_and_std_string_can_be_compared)
 {
+    const char* actual = "same text";
     BOOST_CHECK(match(std::string("same text"), actual));
+    BOOST_CHECK(match(actual, std::string("same text")));
     BOOST_CHECK(!match(std::string("different text"), actual));
+    BOOST_CHECK(!match(actual, std::string("different text")));
 }
 
 BOOST_AUTO_TEST_CASE(null_const_char_pointers_can_be_compared)

--- a/test/test_matcher.cpp
+++ b/test/test_matcher.cpp
@@ -10,6 +10,7 @@
 #include <turtle/matcher.hpp>
 #include <boost/test/unit_test.hpp>
 #include <functional>
+#include <string>
 
 namespace {
 template<typename Expected, typename Actual>
@@ -33,35 +34,49 @@ BOOST_AUTO_TEST_CASE(ref_to_int_and_int_can_be_compared)
     BOOST_CHECK(!match(4, std::cref(i)));
 }
 
-BOOST_AUTO_TEST_CASE(const_char_pointer_and_const_char_pointer_can_be_compared)
+namespace {
+struct fixture
+{
+    fixture() : text("same text")
+    {
+        // Get a pointer to unique memory containing "same text"
+        actual = text.c_str();
+    }
+    const char* actual;
+
+private:
+    std::string text;
+};
+} // namespace
+
+BOOST_FIXTURE_TEST_CASE(const_char_pointer_and_const_char_pointer_can_be_compared, fixture)
 {
     const char* expected = "same text";
-    const char* actual = "same text";
-    BOOST_REQUIRE(expected != actual); // Different pointer values
+    BOOST_REQUIRE(expected != actual);
+    BOOST_REQUIRE(std::string(expected) == actual);
+
     BOOST_CHECK(match(expected, actual));
     const char* unexpected = "different text";
-    BOOST_CHECK(!match(actual, unexpected));
+    BOOST_CHECK(!match(unexpected, actual));
 }
 
-BOOST_AUTO_TEST_CASE(const_char_pointer_and_string_literal_can_be_compared)
+BOOST_FIXTURE_TEST_CASE(const_char_pointer_and_string_literal_can_be_compared, fixture)
 {
-    const char* actual = "same text";
     BOOST_CHECK(match("same text", actual));
     BOOST_CHECK(!match("different text", actual));
 }
 
-BOOST_AUTO_TEST_CASE(const_char_pointer_and_const_char_array_can_be_compared)
+BOOST_FIXTURE_TEST_CASE(const_char_pointer_and_const_char_array_can_be_compared, fixture)
 {
-    const char* actual = "same text";
     const char expected[] = "same text";
+    BOOST_REQUIRE(expected != actual);
     BOOST_CHECK(match(expected, actual));
     const char unexpected[] = "different text";
     BOOST_CHECK(!match(unexpected, actual));
 }
 
-BOOST_AUTO_TEST_CASE(const_char_pointer_and_std_string_can_be_compared)
+BOOST_FIXTURE_TEST_CASE(const_char_pointer_and_std_string_can_be_compared, fixture)
 {
-    const char* actual = "same text";
     BOOST_CHECK(match(std::string("same text"), actual));
     BOOST_CHECK(match(actual, std::string("same text")));
     BOOST_CHECK(!match(std::string("different text"), actual));


### PR DESCRIPTION
The fixture is not always required and can be replaced by definitions in each test which even improves readability.
But we need to fixture to ensure having a unique C-string/`const char*` so that the test cannot simply compare pointers for equality.

Also the tests are partially redundant due to implicit conversions so add test in test_function for actual usage testing of string comparisons.

To be merged after #116 to avoid merge conflicts