### PR TITLE
GHA: Update deprecated images and workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,12 @@ jobs:
         run: |
             export DEBIAN_FRONTEND=noninteractive
             apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
-            apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y sudo software-properties-common curl
-            # Need (newer) git, and the older Ubuntu container may require requesting the key manually using port 80
+            apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y sudo software-properties-common curl lsb-release
+            # Need (newer) git & cmake, and the older Ubuntu container may require requesting the key manually using port 80
             curl -sSL --retry ${NET_RETRY_COUNT:-5} 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE1DD270288B4E6030699E45FA1715D88E1DF1F24' | sudo gpg --dearmor > /etc/apt/trusted.gpg.d/git-core_ubuntu_ppa.gpg
             for i in {1..${NET_RETRY_COUNT:-5}}; do sudo -E add-apt-repository -y ppa:git-core/ppa && break || sleep 10; done
+            curl -sSL --retry ${NET_RETRY_COUNT:-5} 'https://apt.kitware.com/keys/kitware-archive-latest.asc' | sudo gpg --dearmor > /etc/apt/trusted.gpg.d/kitware-archive-latest.gpg
+            for i in {1..${NET_RETRY_COUNT:-5}}; do sudo -E add-apt-repository -y "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" && break || sleep 10; done
             apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
             apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y g++ git cmake
             git config --global pack.threads 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   Formatting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Formatting
       uses: DoozyX/clang-format-lint-action@v0.13
       with:
@@ -42,37 +42,49 @@ jobs:
       matrix:
         include:
           # Linux, gcc
-          - { compiler: gcc-5, cxxstd: '14',       boostBranch: boost-1.65.0, os: ubuntu-18.04 }
-          - { compiler: gcc-5, cxxstd: '14',       boostBranch: boost-1.77.0, os: ubuntu-18.04 }
-          - { compiler: gcc-5, cxxstd: '14,1z',    boostBranch: master,       os: ubuntu-18.04 }
-          - { compiler: gcc-11,cxxstd: '14,17,20', boostBranch: master,       os: ubuntu-20.04 }
+          - { compiler: gcc-5, cxxstd: '14',       boostBranch: boost-1.65.0, os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: gcc-5, cxxstd: '14',       boostBranch: boost-1.77.0, os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: gcc-12,cxxstd: '14,17,20', boostBranch: master,       os: ubuntu-22.04 }
           
           # Linux, clang
-          - { compiler: clang-5.0, cxxstd: '14',       boostBranch: boost-1.65.0, os: ubuntu-18.04 }
-          - { compiler: clang-5.0, cxxstd: '14',       boostBranch: boost-1.77.0, os: ubuntu-18.04 }
-          - { compiler: clang-5.0, cxxstd: '14,1z',    boostBranch: master,       os: ubuntu-18.04 }
-          - { compiler: clang-12,  cxxstd: '14,17,20', boostBranch: master,       os: ubuntu-20.04 }
+          - { compiler: clang-5.0, cxxstd: '14',       boostBranch: boost-1.65.0, os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: clang-5.0, cxxstd: '14',       boostBranch: boost-1.77.0, os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: clang-14,  cxxstd: '14,17,20', boostBranch: master,       os: ubuntu-22.04 }
 
           - { name: Collect coverage, coverage: yes,
               compiler: gcc-8,     cxxstd: '14',       boostBranch: master,       os: ubuntu-20.04 }
 
     timeout-minutes: 120
     runs-on: ${{matrix.os}}
+    container: ${{matrix.container}}
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Prepare container environment
+        if: matrix.container
+        run: |
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+            apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y sudo software-properties-common curl
+            # Need (newer) git, and the older Ubuntu container may require requesting the key manually using port 80
+            curl -sSL --retry ${NET_RETRY_COUNT:-5} 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE1DD270288B4E6030699E45FA1715D88E1DF1F24' | sudo gpg --dearmor > /etc/apt/trusted.gpg.d/git-core_ubuntu_ppa.gpg
+            for i in {1..${NET_RETRY_COUNT:-5}}; do sudo -E add-apt-repository -y ppa:git-core/ppa && break || sleep 10; done
+            apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+            apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y g++ git cmake
+            git config --global pack.threads 0
+
+      - uses: actions/checkout@v3
         with:
           # For coverage builds fetch the whole history, else only 1 commit using a 'fake ternary'
           fetch-depth: ${{ matrix.coverage && '0' || '1' }}
 
       # Checking out Boost and all its submodules takes ages...
       - name: Cache Boost
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: boost-root
           key: boost-${{matrix.boostBranch}}
       - name: Checkout Boost
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: boostorg/boost
           ref: ${{matrix.boostBranch}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
       BOOST_VERSION: 1.71.0
       BOOST_ROOT: ${{github.workspace}}/dependencies/boost
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           repository: boostorg/boost
           ref: boost-${{env.BOOST_VERSION}}


### PR DESCRIPTION
- The Ubuntu 18.04 runners were deprecated and removed.
- `actions/checkout@v2` uses node12 which is deprecated.
- Same for `actions/cache@v2`