### PR TITLE
Enhance CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
             apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
             apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y g++ git cmake
             git config --global pack.threads 0
+            git config --global --add safe.directory "$GITHUB_WORKSPACE"  # Avoid ownership issues of repo in container
 
       - uses: actions/checkout@v4
         with:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ environment:
       BOOST: 1_65_1
       CMAKE: true
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      BOOST: 1_77_0
+      BOOST: 1_83_0
       CMAKE: true
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@
 # subject to the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
-# Copyright Mathieu Champlon 2015.
-# Copyright Alexander Grund 2020.
+# Copyright 2015 Mathieu Champlon
+# Copyright 2020-2025 Alexander Grund
 
 skip_branch_with_pr: true
 
@@ -19,17 +19,29 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       BOOST: 1_65_1
       TOOLSET: msvc-14.1
-      CXX_STANDARD: 14
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      BOOST: 1_67_0
+      BOOST: 1_69_0
       TOOLSET: msvc-14.1
-      CXX_STANDARD: 14
-      # CXX_STANDARD: 17
+      CXX_STANDARD: 14,17
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      BOOST: 1_83_0
+      TOOLSET: msvc-14.3
+      CXX_STANDARD: 14,17,20
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      BOOST: 1_86_0
+      TOOLSET: msvc-14.3
+      CXX_STANDARD: 14,17,20
+
+    # CMake builds
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       BOOST: 1_65_1
       CMAKE: true
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       BOOST: 1_83_0
+      CMAKE: true
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      BOOST: 1_86_0
       CMAKE: true
 
 install:
@@ -55,7 +67,7 @@ build_script:
   - cd %BOOST_ROOT%
   - call bootstrap.bat
   - cd %APPVEYOR_BUILD_FOLDER%
-  - if NOT "%CXX_STANDARD%"=="" set CXX_FLAGS=cxxflags=/std:c++%CXX_STANDARD%
+  - if NOT "%CXX_STANDARD%"=="" set CXX_FLAGS=cxxstd=%CXX_STANDARD%
   - set BUILD_ARGS=address-model=32,64 variant=debug,release
   - call scripts\build.bat --toolset=%TOOLSET% %CXX_FLAGS% -j3
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,10 @@ branches:
     - main
 
 environment:
+  global:
+    ADDRESS_MODEL: 32,64
+    VARIANT: debug,release
+
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       BOOST: 1_65_1
@@ -23,15 +27,24 @@ environment:
       BOOST: 1_69_0
       TOOLSET: msvc-14.1
       CXX_STANDARD: 14,17
-
+      ADDRESS_MODEL: 64
+      VARIANT: debug
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       BOOST: 1_83_0
       TOOLSET: msvc-14.3
       CXX_STANDARD: 14,17,20
+      ADDRESS_MODEL: 64
+      VARIANT: debug
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       BOOST: 1_86_0
       TOOLSET: msvc-14.3
-      CXX_STANDARD: 14,17,20
+      CXX_STANDARD: 14,17
+      ADDRESS_MODEL: 64
+      VARIANT: debug
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      BOOST: 1_86_0
+      TOOLSET: msvc-14.3
+      CXX_STANDARD: 20
 
     # CMake builds
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
@@ -68,7 +81,7 @@ build_script:
   - call bootstrap.bat
   - cd %APPVEYOR_BUILD_FOLDER%
   - if NOT "%CXX_STANDARD%"=="" set CXX_FLAGS=cxxstd=%CXX_STANDARD%
-  - set BUILD_ARGS=address-model=32,64 variant=debug,release
+  - set BUILD_ARGS=address-model=%ADDRESS_MODEL% variant=%VARIANT%
   - call scripts\build.bat --toolset=%TOOLSET% %CXX_FLAGS% -j3
 
 for:

--- a/include/turtle/config.hpp
+++ b/include/turtle/config.hpp
@@ -1,6 +1,7 @@
 // http://turtle.sourceforge.net
 //
 // Copyright Mathieu Champlon 2009
+// Copyright 2020-2025 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
@@ -28,6 +29,19 @@
 #    ifndef MOCK_NO_UNCAUGHT_EXCEPTIONS
 #        define MOCK_UNCAUGHT_EXCEPTIONS
 #    endif
+#endif
+
+#if BOOST_VERSION >= 107700
+#    define MOCK_CXX_VERSION BOOST_CXX_VERSION
+#elif defined(_MSC_VER)
+#    ifdef _MSVC_LANG
+#        define MOCK_CXX_VERSION _MSVC_LANG
+#    elif defined(_HAS_CXX17)
+#        define MOCK_CXX_VERSION 201703L
+#    endif
+#endif
+#ifndef MOCK_CXX_VERSION
+#    define MOCK_CXX_VERSION __cplusplus
 #endif
 
 #endif // MOCK_CONFIG_HPP_INCLUDED

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 # Copyright (C) 2015 Mathieu Champlon
+# Copyright (C) 2025 Alexander Grund
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
@@ -18,3 +19,6 @@ scripts/build_doc.sh "$@"
 
 cd "$BOOST_ROOT"
 ./b2 "$PROJECT_DIR/doc//mock_examples" -q "$@"
+
+cd "$BOOST_ROOT"
+./b2 "$PROJECT_DIR/test//inspect" -q "$@"

--- a/test/Jamfile.jam
+++ b/test/Jamfile.jam
@@ -1,4 +1,5 @@
-# Copyright Mathieu Champlon 2012
+# Copyright 2012 Mathieu Champlon
+# Copyright 2025 Alexander Grund
 #
 # Distributed under the Boost Software License version 1.0. (See
 # accompanying file LICENSE_1_0.txt or copy at
@@ -15,11 +16,8 @@ project
 
 path-constant parent : .. ;
 
-alias mock_inspect :
-  [ run /boost/tools/inspect//inspect/<variant>release
-       : $(parent) -text -brief : : : inspect
-  ]
-;
+run /boost/tools/inspect//inspect/<variant>release : $(parent) -text -brief : : <test-info>always_show_run_output : inspect ;
+explicit inspect ;
 
 rule run-test ( name )
 {

--- a/test/detail/test_is_functor.cpp
+++ b/test/detail/test_is_functor.cpp
@@ -67,6 +67,8 @@ BOOST_AUTO_TEST_CASE(function_pointer_is_functor)
     is_not_functor(&f2);
 }
 
+// ptr_fun, bin1st is removed in C++17
+#if MOCK_CXX_VERSION < 201703L
 BOOST_AUTO_TEST_CASE(std_ptr_fun_is_functor)
 {
     is_functor(std::ptr_fun(&f1));
@@ -77,6 +79,7 @@ BOOST_AUTO_TEST_CASE(std_bind_first_is_functor)
 {
     is_functor(std::bind1st(std::ptr_fun(&f2), ""));
 }
+#endif
 
 BOOST_AUTO_TEST_CASE(bind_is_functor)
 {


### PR DESCRIPTION
- Fix an issue on GHA where ownership of the repo inside the container causes git to fail (owner is the outside user)
- Add VS 2022 to appveyor
- Test with Boost 1.83/1.86 on appveyor
- Use cxxstd=yy for `b2` to allow e.g. testing multiple version at once
- Make the `inspect` target explicit and call from the build script. Otherwise mixing CMake and B2 builds causes failures as the build files generated by CMake are not validly named (for `inspect`)

Factored out from #127 