### PR TITLE
Enhance CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
 
       - name: Boost build
         run: |
+          set -x
           ./b2 "$GITHUB_WORKSPACE/test" -q $B2_FLAGS -j3
           ./b2 "$GITHUB_WORKSPACE/doc//mock_examples" -q $B2_FLAGS "$@"
         working-directory: ${{env.BOOST_ROOT}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
           - { compiler: clang-19,  cxxstd: '14,17,20,23,2c', boostBranch: boost-1.86.0, os: ubuntu-24.04 }
           - { compiler: clang-20,  cxxstd: '14,17,20,23,2c', boostBranch: boost-1.86.0, os: ubuntu-24.04 }
           - { compiler: clang-21,  cxxstd: '14,17,20,23,2c', boostBranch: boost-1.86.0, os: ubuntu-26.04 }
-          - { compiler: clang-22,  cxxstd: '14,17,20,23,2c', boostBranch: boost-1.86.0, os: ubuntu-26.04 }
-          - { compiler: clang-22,  cxxstd: '14,17,20,23,2c', boostBranch: master,       os: ubuntu-26.04 }
+          - { compiler: clang-22,  cxxstd: '14,17,20,23,2c', boostBranch: boost-1.86.0, os: ubuntu-26.04, cxxflags: '-Wno-c2y-extensions' }
+          - { compiler: clang-22,  cxxstd: '14,17,20,23,2c', boostBranch: master,       os: ubuntu-26.04, cxxflags: '-Wno-c2y-extensions' }
 
           # Windows
           - { toolset: gcc,       os: windows-2022,         cxxstd: 17,     generator: 'MinGW Makefiles' }
@@ -73,6 +73,8 @@ jobs:
     timeout-minutes: 120
     runs-on: ${{matrix.os}}
     container: ${{matrix.container}}
+    env:
+      B2_CXXFLAGS: ${{matrix.cxxflags}}
 
     steps:
       - name: Prepare container environment
@@ -138,6 +140,9 @@ jobs:
           B2_FLAGS+=" --toolset=$B2_TOOLSET cxxstd=${{matrix.cxxstd}}"
           if [[ "${{matrix.coverage}}" == "yes" ]]; then
             B2_FLAGS+=" cxxflags=--coverage linkflags=--coverage"
+          fi
+          if [[ -n $B2_CXXFLAGS ]]; then
+            B2_FLAGS+=" cxxflags='$B2_CXXFLAGS'"
           fi
           echo "B2_FLAGS=$B2_FLAGS" >> $GITHUB_ENV
 
@@ -210,6 +215,9 @@ jobs:
           fi
           if [[ "${{matrix.generator}}" == "MinGW"* ]]; then
             extra_args+=(-DCMAKE_CXX_FLAGS="-Wa,-mbig-obj")
+          fi
+          if [[ -n $B2_CXXFLAGS ]]; then
+            extra_args+=(-DCMAKE_CXX_FLAGS="$B2_CXXFLAGS")
           fi
 
           CXX_STD=${CXX_STD##*,}  # Extract last value

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
   Formatting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Formatting
-      uses: DoozyX/clang-format-lint-action@v0.13
+      uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73 # v0.20
       with:
         clangFormatVersion: 10
 
@@ -93,19 +93,19 @@ jobs:
             git config --global pack.threads 0
             git config --global --add safe.directory "$GITHUB_WORKSPACE"  # Avoid ownership issues of repo in container
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # For coverage builds fetch the whole history, else only 1 commit using a 'fake ternary'
           fetch-depth: ${{ matrix.coverage && '0' || '1' }}
 
       # Checking out Boost and all its submodules takes ages...
       - name: Cache Boost
-        uses: actions/cache@v4
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: boost-root
           key: boost-${{matrix.boostBranch}}
       - name: Checkout Boost
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: boostorg/boost
           ref: ${{matrix.boostBranch}}
@@ -151,7 +151,7 @@ jobs:
           echo "BOOST_ROOT=${{github.workspace}}/../boost-root" >> $GITHUB_ENV
 
       - name: Cache ccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         if: startsWith(matrix.os, 'ubuntu')
         with:
           key: ${{matrix.os}}-${{matrix.compiler}}-${{matrix.boostBranch}}
@@ -188,7 +188,7 @@ jobs:
           lcov --list coverage.info
       - name: Upload coverage
         if: matrix.coverage
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
           path-to-lcov: ${{github.workspace}}/coverage.info
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,13 +187,17 @@ jobs:
           fi
           GCOV=gcov-${ver}
           lcov --version
-          lcov --gcov-tool="$GCOV" --directory "$GITHUB_WORKSPACE/test" --capture --output-file all.info
+          LCOV_OPTIONS=()
+          LCOV_OPTIONS+=(--rc "branch_coverage=0")
+          LCOV_OPTIONS+=(--ignore-errors "inconsistent,mismatch,unused")
+
+          lcov "${LCOV_OPTIONS[@]}" --gcov-tool="$GCOV" --directory "$GITHUB_WORKSPACE/test" --capture --output-file all.info
           # dump a summary on the console
-          lcov --list all.info
+          lcov "${LCOV_OPTIONS[@]}" --list all.info
           # Limit to our files (header-only in this case)
-          lcov --extract all.info "$GITHUB_WORKSPACE/include/*" --output-file coverage.info
+          lcov "${LCOV_OPTIONS[@]}" --extract all.info "$GITHUB_WORKSPACE/include/*" --output-file coverage.info
           # Output what was collected
-          lcov --list coverage.info
+          lcov "${LCOV_OPTIONS[@]}" --list coverage.info
       - name: Upload coverage
         if: matrix.coverage
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,9 +196,10 @@ jobs:
           echo "LD_LIBRARY_PATH=$PWD/stage/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: CMake build
+        env:
+          CXX_STD: ${{matrix.cxxstd}}
         run: |
           mkdir build && cd build
-          CXX_STANDARD="${{matrix.cxxstd}}"
           if [[ "${{matrix.os}}" == "windows-"* ]]; then
             extra_args=()
           else
@@ -210,8 +211,19 @@ jobs:
           if [[ "${{matrix.generator}}" == "MinGW"* ]]; then
             extra_args+=(-DCMAKE_CXX_FLAGS="-Wa,-mbig-obj")
           fi
+
+          CXX_STD=${CXX_STD##*,}  # Extract last value
+          case "$CXX_STD" in
+            latest) CXX_STD="" ;; # MSVC: Use default
+            # Use older ones instead of aliases
+            2b) CXX_STD=20 ;;
+            2c) CXX_STD=23 ;;
+          esac
+          if [[ -n "$CXX_STD" ]]; then
+            extra_args+=(-DCMAKE_CXX_STANDARD="$CXX_STD")
+          fi
           echo "Using extra args: ${extra_args[*]}"
-          cmake .. -DCMAKE_BUILD_TYPE=Debug -DBoost_ROOT="$BOOST_ROOT/stage" -DCMAKE_CXX_STANDARD="${CXX_STANDARD##*,}" "${extra_args[@]}" -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_VERBOSE=ON
+          cmake .. -DCMAKE_BUILD_TYPE=Debug -DBoost_ROOT="$BOOST_ROOT/stage" "${extra_args[@]}" -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_VERBOSE=ON
           cmake --build . --config Debug --parallel 3
           ctest --output-on-failure --build-config Debug
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,21 +42,30 @@ jobs:
       matrix:
         include:
           # Linux, gcc
-          - { compiler: gcc-7,  cxxstd: '14,17',    boostBranch: boost-1.86.0, os: ubuntu-latest, container: 'ubuntu:20.04' }
-          - { compiler: gcc-10, cxxstd: '14,17,20', boostBranch: boost-1.86.0, os: ubuntu-22.04 }
-          - { compiler: gcc-12, cxxstd: '14,17,20', boostBranch: master,       os: ubuntu-22.04 }
-          - { compiler: gcc-14, cxxstd: '14,17,20', boostBranch: boost-1.86.0, os: ubuntu-24.04 }
-          - { compiler: gcc-14, cxxstd: '14,17,20', boostBranch: master,       os: ubuntu-24.04 }
+          - { compiler: gcc-7,  cxxstd: '14,17',          boostBranch: boost-1.86.0, os: ubuntu-latest, container: 'ubuntu:20.04' }
+          - { compiler: gcc-10, cxxstd: '14,17,20',       boostBranch: boost-1.86.0, os: ubuntu-22.04 }
+          - { compiler: gcc-12, cxxstd: '14,17,20',       boostBranch: master,       os: ubuntu-22.04 }
+          - { compiler: gcc-14, cxxstd: '14,17,20,23,2c', boostBranch: boost-1.86.0, os: ubuntu-24.04 }
+          - { compiler: gcc-14, cxxstd: '14,17,20,23,2c', boostBranch: master,       os: ubuntu-24.04 }
+          - { compiler: gcc-15, cxxstd: '14,17,20,23,2c', boostBranch: boost-1.86.0, os: ubuntu-26.04 }
+          - { compiler: gcc-16, cxxstd: '14,17,20,23,26', boostBranch: boost-1.86.0, os: ubuntu-26.04 }
+          - { compiler: gcc-16, cxxstd: '14,17,20,23,26', boostBranch: master,       os: ubuntu-26.04 }
 
           # Linux, clang
-          - { compiler: clang-14,  cxxstd: '14,17,20', boostBranch: boost-1.86.0, os: ubuntu-24.04 }
-          - { compiler: clang-18,  cxxstd: '14,17,20', boostBranch: boost-1.86.0, os: ubuntu-24.04 }
-          - { compiler: clang-18,  cxxstd: '14,17,20', boostBranch: master,       os: ubuntu-24.04 }
+          - { compiler: clang-14,  cxxstd: '14,17,20',       boostBranch: boost-1.86.0, os: ubuntu-24.04 }
+          - { compiler: clang-18,  cxxstd: '14,17,20,23,2c', boostBranch: boost-1.86.0, os: ubuntu-24.04 }
+          - { compiler: clang-18,  cxxstd: '14,17,20,23,2c', boostBranch: master,       os: ubuntu-24.04 }
+          - { compiler: clang-19,  cxxstd: '14,17,20,23,2c', boostBranch: boost-1.86.0, os: ubuntu-24.04 }
+          - { compiler: clang-20,  cxxstd: '14,17,20,23,2c', boostBranch: boost-1.86.0, os: ubuntu-24.04 }
+          - { compiler: clang-21,  cxxstd: '14,17,20,23,2c', boostBranch: boost-1.86.0, os: ubuntu-26.04 }
+          - { compiler: clang-22,  cxxstd: '14,17,20,23,2c', boostBranch: boost-1.86.0, os: ubuntu-26.04 }
+          - { compiler: clang-22,  cxxstd: '14,17,20,23,2c', boostBranch: master,       os: ubuntu-26.04 }
 
           # Windows
-          - { toolset: msvc-14.2, os: windows-2019,  cxxstd: 14, generator: 'Visual Studio 16 2019' }
-          - { toolset: gcc,       os: windows-2019,  cxxstd: 17, generator: 'MinGW Makefiles' }
-          - { toolset: msvc-14.3, os: windows-2022,  cxxstd: 20, generator: 'Visual Studio 17 2022' }
+          - { toolset: gcc,       os: windows-2022,         cxxstd: 17,     generator: 'MinGW Makefiles' }
+          - { toolset: msvc-14.3, os: windows-2022,         cxxstd: 20,     generator: 'Visual Studio 17 2022' }
+          - { toolset: msvc-14.5, os: windows-2025-vs2026,  cxxstd: 20,     generator: 'Visual Studio 18 2026' }
+          - { toolset: msvc-14.5, os: windows-2025-vs2026,  cxxstd: latest, generator: 'Visual Studio 18 2026' }
 
           - { name: Collect coverage, coverage: yes,
               compiler: gcc-8, cxxstd: '14', boostBranch: boost-1.86.0, os: ubuntu-latest, container: 'ubuntu:20.04' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,14 @@ jobs:
             extra_args+=(-G "${{matrix.generator}}")
           fi
           if [[ "${{matrix.generator}}" == "MinGW"* ]]; then
+            # Avoid "Fatal error: can't write 1214 bytes to section .text of [...] 'file too big' [...] too many sections"
             extra_args+=(-DCMAKE_CXX_FLAGS="-Wa,-mbig-obj")
+            # GHA has 2 MinGWs installed which must not be mixed,
+            # so make sure the executables pick up the libraries/DLLs matching the compiler
+            gcc_folder=$(dirname "$(which g++)")
+            prefix=${gcc_folder%/bin}
+            echo "GCC prefix: $prefix"
+            export PATH="$prefix/bin:$prefix/lib:$PATH"
           fi
           if [[ -n $B2_CXXFLAGS ]]; then
             extra_args+=(-DCMAKE_CXX_FLAGS="$B2_CXXFLAGS")
@@ -242,7 +249,7 @@ jobs:
           if [[ -n "$CXX_STD" ]]; then
             extra_args+=(-DCMAKE_CXX_STANDARD="$CXX_STD")
           fi
-          echo "Using extra args: ${extra_args[*]}"
+          set +x
           cmake .. -DCMAKE_BUILD_TYPE=Debug -DBoost_ROOT="$BOOST_ROOT/stage" "${extra_args[@]}" -DCMAKE_VERBOSE_MAKEFILE=ON -DBoost_DEBUG=ON -DBoost_VERBOSE=ON
           cmake --build . --config Debug --parallel 3
           ctest --output-on-failure --build-config Debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           - { toolset: msvc-14.5, os: windows-2025-vs2026,  cxxstd: latest, generator: 'Visual Studio 18 2026' }
 
           - { name: Collect coverage, coverage: yes,
-              compiler: gcc-8, cxxstd: '14', boostBranch: boost-1.86.0, os: ubuntu-latest, container: 'ubuntu:20.04' }
+              compiler: gcc-13, cxxstd: '14,2b', boostBranch: boost-1.86.0, os: ubuntu-24.04 }
 
     timeout-minutes: 120
     runs-on: ${{matrix.os}}
@@ -177,9 +177,17 @@ jobs:
 
       - name: Collect coverage
         if: matrix.coverage
+        working-directory: ${{github.workspace}} # Make sure file is found by upload action
         run: |
+          B2_COMPILER=${{matrix.compiler}}
+          if [[ "$B2_COMPILER" =~ gcc- ]]; then
+            ver="${B2_COMPILER##*gcc-}"
+          else
+            ver=8
+          fi
+          GCOV=gcov-${ver}
           lcov --version
-          lcov --gcov-tool=gcov-8 --directory "$GITHUB_WORKSPACE/test" --capture --output-file all.info
+          lcov --gcov-tool="$GCOV" --directory "$GITHUB_WORKSPACE/test" --capture --output-file all.info
           # dump a summary on the console
           lcov --list all.info
           # Limit to our files (header-only in this case)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 # Copyright 2015 Mathieu Champlon
-# Copyright 2020-2025 Alexander Grund
+# Copyright 2020-2026 Alexander Grund
 
 skip_branch_with_pr: true
 
@@ -30,31 +30,35 @@ environment:
       ADDRESS_MODEL: 64
       VARIANT: debug
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      BOOST: 1_83_0
+      BOOST: 1_85_0
       TOOLSET: msvc-14.3
       CXX_STANDARD: 14,17,20
       ADDRESS_MODEL: 64
       VARIANT: debug
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      BOOST: 1_86_0
+      BOOST: 1_89_0
       TOOLSET: msvc-14.3
       CXX_STANDARD: 14,17
       ADDRESS_MODEL: 64
       VARIANT: debug
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      BOOST: 1_86_0
+      BOOST: 1_89_0
       TOOLSET: msvc-14.3
       CXX_STANDARD: 20
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2026
+      BOOST: 1_91_0
+      TOOLSET: msvc-14.5
+      CXX_STANDARD: 20,latest
 
     # CMake builds
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       BOOST: 1_65_1
       CMAKE: true
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      BOOST: 1_83_0
+      BOOST: 1_85_0
       CMAKE: true
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      BOOST: 1_86_0
+      BOOST: 1_89_0
       CMAKE: true
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,12 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2026
       BOOST: 1_91_0
       TOOLSET: msvc-14.5
-      CXX_STANDARD: 20,latest
+      CXX_STANDARD: 20
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2026
+      BOOST: 1_91_0
+      TOOLSET: msvc-14.5
+      CXX_STANDARD: latest
 
     # CMake builds
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015


### PR DESCRIPTION
- Add newer compilers
   - GCC 15 & 16
   - Clang 19-22
   - MSVC 2026
- Show B2 parameters (full invocation)
- Handle C++ standards passed to B2 in CMake CI ("latest"->"", "2b"->"20", "2c"->"23") so CMake understands it
- Ignore `-Wc2y-extensions` on CI emitted by Clang 22 due to Boost.Test
- Ignore LCov warnings `inconsistent,mismatch,unused`, false positives mostly due to Boost.Test magic
- Fix MinGW tests: Seg fault due to picking up conflicting `libstdc++-6.dll` (`/mingw64` and Git-MinGW)